### PR TITLE
CI Update and Singularity Deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   - python --version
   - which pip
   - pip --version
-  # QT_DEBUG_PLUGINS
+  # QT_DEBUG_PLUGINS 
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       sudo apt install -y libxkbcommon-x11-0;
       pip install -e .[test];


### PR DESCRIPTION
Updated `.travis.yml` and added in a singularity definition file just called `Singularity`.

The travis CI now has two stages: `test` and `singularity-build-push`.

The test section currently runs both the parallel and series tests for two versions of Python (3.7.5 and 3.6.9), with the same version of gcc (version 6, this could run for 6 and 7 but it would double the test time).

If the CI is running on the master branch or if a tag has just been made then the `singularity-build-push` stage will execute after the tests, this will build a singularity image and push it to the singularity registry.

The new image will be tagged either with the branch name or with the tag name. This way the `master` image will always give the latest version, and tagging a release acts to archive previous images.

Some examples from travis:

 - dev - only tests ran: https://travis-ci.com/RobertRosca/EXtra-foam/builds/139371279
 - master - triggers tests and image build/push: https://travis-ci.com/RobertRosca/EXtra-foam/builds/139372390
 - tag - triggers tests and image build/push: https://travis-ci.com/RobertRosca/EXtra-foam/builds/139372674

Images can be found [here](https://cloud.sylabs.io/library/_container/5de7ab59c9435e18ec5622e5) where you can see one tagged as `master`, and one tagged as `v0.0.0`.

Still have to:

 - Send Jun keys to add to Travis for the Singularity deployment stage
 - See if it's possible to use the European-XFEL organisation as an account on cloud.sylabs.io - as far as I can tell this can't be done, so the images will likely have to stay under my account for now
 - Add in help, labels, and runscript (maybe) to the image definition
 - Optional(?) add additional tests to the matrix, e.g. different versions of GCC, which act as a more rigorous test during merges to master
 - Optional(?) only enable some tests for merge to master