### PR TITLE
Improve Redis server management

### DIFF
--- a/extra_foam/config.py
+++ b/extra_foam/config.py
@@ -215,11 +215,13 @@ class _Config(dict):
         # -------------------------------------------------------------
         # absolute path of the Redis server executable
         "REDIS_EXECUTABLE": osp.join(_abs_dirpath, "thirdparty/bin/redis-server"),
-        # default REDIS port used in testing. Each detector has its
-        # dedicated REDIS port.
+        # default Redis port used in testing. Each detector has its
+        # dedicated Redis port.
         "REDIS_PORT": 6379,
         # maximum attempts to ping the Redis server before shutting down the app
-        "REDIS_MAX_PING_ATTEMPTS": 10,
+        "REDIS_MAX_PING_ATTEMPTS": 3,
+        # interval for pinging the Redis server from the main GUI, in milliseconds
+        "REDIS_PING_ATTEMPT_INTERVAL": 5000,
         # If the path is given, redis-py will use UnixDomainSocketConnection.
         # Otherwise, normal TCP socket connection.
         "REDIS_UNIX_DOMAIN_SOCKET_PATH": "",

--- a/extra_foam/database/mondata.py
+++ b/extra_foam/database/mondata.py
@@ -9,7 +9,6 @@ All rights reserved.
 """
 import time
 
-from .metadata import Metadata as mt
 from .base_proxy import _AbstractProxy
 from .db_utils import redis_except_handler
 from ..config import config

--- a/extra_foam/database/tests/test_metadata.py
+++ b/extra_foam/database/tests/test_metadata.py
@@ -1,7 +1,7 @@
 import unittest
 
 from extra_foam.config import AnalysisType
-from extra_foam.database.metadata import MetaMetadata
+from extra_foam.database.metadata import Metadata, MetaMetadata
 from extra_foam.database import MetaProxy, MonProxy
 from extra_foam.processes import wait_until_redis_shutdown
 from extra_foam.services import start_redis_server
@@ -13,8 +13,6 @@ class TestDataProxy(unittest.TestCase):
         start_redis_server()
 
         cls._meta = MetaProxy()
-        cls._meta.initialize_analysis_types()
-
         cls._mon = MonProxy()
 
     @classmethod
@@ -44,7 +42,7 @@ class TestDataProxy(unittest.TestCase):
         # register an analysis type twice
         self._meta.register_analysis(type2)
         self.assertTrue(self._meta.has_all_analysis([type1, type2]))
-        self.assertEqual('2', self._meta.hget(self._meta.ANALYSIS_TYPE, type2))
+        self.assertEqual('2', self._meta.hget(Metadata.ANALYSIS_TYPE, type2))
 
         # unregister an analysis type
         self._meta.unregister_analysis(type1)
@@ -52,7 +50,7 @@ class TestDataProxy(unittest.TestCase):
 
         # unregister an analysis type which has not been registered
         self._meta.unregister_analysis(type3)
-        self.assertEqual('0', self._meta.hget(self._meta.ANALYSIS_TYPE, type3))
+        self.assertEqual('0', self._meta.hget(Metadata.ANALYSIS_TYPE, type3))
 
     def testMetaMetadata(self):
         class Dummy(metaclass=MetaMetadata):

--- a/extra_foam/gui/image_tool/tests/test_image_tool.py
+++ b/extra_foam/gui/image_tool/tests/test_image_tool.py
@@ -21,7 +21,7 @@ from extra_foam.pipeline.exceptions import ImageProcessingError
 from extra_foam.pipeline.processors.tests import _BaseProcessorTest
 from extra_foam.processes import wait_until_redis_shutdown
 from extra_foam.services import Foam
-from extra_foam.database import MetaProxy
+from extra_foam.database import Metadata, MetaProxy
 
 app = mkQApp()
 
@@ -618,10 +618,10 @@ class TestImageTool(unittest.TestCase, _BaseProcessorTest):
         self.assertFalse(record_btn.isChecked())
 
         # switch to "azimuthal integration 1D"
-        self.assertEqual('0', self._meta.hget(self._meta.ANALYSIS_TYPE, AnalysisType.AZIMUTHAL_INTEG))
+        self.assertEqual('0', self._meta.hget(Metadata.ANALYSIS_TYPE, AnalysisType.AZIMUTHAL_INTEG))
         tab.tabBarClicked.emit(TabIndex.AZIMUTHAL_INTEG_1D)
         tab.setCurrentIndex(TabIndex.AZIMUTHAL_INTEG_1D)
-        self.assertEqual('1', self._meta.hget(self._meta.ANALYSIS_TYPE, AnalysisType.AZIMUTHAL_INTEG))
+        self.assertEqual('1', self._meta.hget(Metadata.ANALYSIS_TYPE, AnalysisType.AZIMUTHAL_INTEG))
 
         # switch to "geometry"
         tab.tabBarClicked.emit(TabIndex.GEOMETRY)

--- a/extra_foam/logger.py
+++ b/extra_foam/logger.py
@@ -22,20 +22,17 @@ def create_logger():
     """Create the logger object for the whole API."""
     name = "EXtra-foam"
     logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
 
     log_file = os.path.join(ROOT_PATH, name + ".log")
     fh = TimedRotatingFileHandler(log_file, when='midnight')
 
     fh.suffix = "%Y%m%d"
-    fh.setLevel(logging.INFO)
     formatter = logging.Formatter(
         '%(asctime)s - %(filename)s - %(levelname)s - %(message)s'
     )
     fh.setFormatter(formatter)
 
     ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
         '%(filename)s - %(levelname)s - %(message)s'
     )
@@ -49,3 +46,4 @@ def create_logger():
 
 
 logger = create_logger()
+logger.setLevel(logging.INFO)

--- a/extra_foam/pipeline/processors/tests/test_base_proc.py
+++ b/extra_foam/pipeline/processors/tests/test_base_proc.py
@@ -53,7 +53,6 @@ class TestBaseProcessor(unittest.TestCase):
         start_redis_server()
 
         cls._meta = MetaProxy()
-        cls._meta.initialize_analysis_types()
 
     @classmethod
     def tearDownClass(cls):

--- a/extra_foam/utils.py
+++ b/extra_foam/utils.py
@@ -173,7 +173,7 @@ def _get_system_gpu_info():
         return info
     except FileNotFoundError as e:
         # raised when 'nvidia-smi' does not exist
-        logger.info(repr(e))
+        logger.debug(repr(e))
         return GpuInfo()
     except Exception as e:
         # We don't want to prevent the app from starting simply because


### PR DESCRIPTION
- Allow starting instances with different detectors without warning
  message;
- In the terminal, "--topic" becomes a positional argument;
- Allow to shutdown others' Redis server to avoid zombie Redis server
  occupying the port;
- Fix bug in "extra-foam-kill";
- Fix web monitor;
- Improve global Redis client connection initialization;
- Fix logger level.