### PR TITLE
Fix gain/offset slicer for train-resolved detector.

### DIFF
--- a/extra_foam/algorithms/imageproc_py.py
+++ b/extra_foam/algorithms/imageproc_py.py
@@ -36,9 +36,7 @@ def nanmean_image_data(data, *, kept=None):
 
 
 def correct_image_data(data, *,
-                       gain=None,
-                       offset=None,
-                       slicer=slice(None, None)):
+                       gain=None, offset=None, slicer=slice(None, None)):
     """Apply gain and/or offset correct to image data.
 
     :param numpy.array data: image data, Shape = (y, x) or (indices, y, x)
@@ -46,14 +44,23 @@ def correct_image_data(data, *,
         shape as the image data.
     :param None/numpy.array offset: offset constants, which has the same
         shape as the image data.
-    :param slice slicer: gain and offset slicer.
+    :param slice slicer: gain and offset slicer, which is used only for
+        an array of images. It is ignored for if data is a single image.
     """
-    if gain is not None and offset is not None:
-        correctGainOffset(data, gain[slicer], offset[slicer])
-    elif offset is not None:
-        correctOffset(data, offset[slicer])
-    elif gain is not None:
-        correctGain(data, gain[slicer])
+    if data.ndim == 3:
+        if gain is not None and offset is not None:
+            correctGainOffset(data, gain[slicer], offset[slicer])
+        elif offset is not None:
+            correctOffset(data, offset[slicer])
+        elif gain is not None:
+            correctGain(data, gain[slicer])
+    else:
+        if gain is not None and offset is not None:
+            correctGainOffset(data, gain, offset)
+        elif offset is not None:
+            correctOffset(data, offset)
+        elif gain is not None:
+            correctGain(data, gain)
 
 
 def mask_image_data(image_data, *,

--- a/extra_foam/algorithms/tests/test_image_proc.py
+++ b/extra_foam/algorithms/tests/test_image_proc.py
@@ -203,19 +203,19 @@ class TestImageProc(unittest.TestCase):
         # offset only
         img = np.array([[1, 2, 3], [3, np.nan, np.nan]], dtype=np.float32)
         offset = np.array([[1, 2, 1], [2, np.nan, np.nan]], dtype=np.float32)
-        correct_image_data(img, offset=offset)
+        correct_image_data(img, offset=offset, slicer=None)
         np.testing.assert_array_equal(
             np.array([[0, 0, 2], [1, np.nan, np.nan]], dtype=np.float32), img)
 
         # gain only
         gain = np.array([[1, 2, 1], [2, 2, 1]], dtype=np.float32)
-        correct_image_data(img, gain=gain)
+        correct_image_data(img, gain=gain, slicer=None)
         np.testing.assert_array_equal(
             np.array([[0, 0, 2], [2, np.nan, np.nan]], dtype=np.float32), img)
 
         # both gain and offset
         img = np.array([[1, 2, 3], [3, np.nan, np.nan]], dtype=np.float32)
-        correct_image_data(img, gain=gain, offset=offset)
+        correct_image_data(img, gain=gain, offset=offset, slicer=None)
         np.testing.assert_array_equal(
             np.array([[0, 0, 2], [2, np.nan, np.nan]], dtype=np.float32), img)
 

--- a/extra_foam/gui/ctrl_widgets/calibration_ctrl_widget.py
+++ b/extra_foam/gui/ctrl_widgets/calibration_ctrl_widget.py
@@ -30,9 +30,7 @@ class CalibrationCtrlWidget(_AbstractCtrlWidget):
         super().__init__(*args, **kwargs)
 
         self._correct_gain_cb = QCheckBox()
-        self._correct_gain_cb.setChecked(True)
         self._correct_offset_cb = QCheckBox()
-        self._correct_offset_cb.setChecked(True)
 
         self._load_gain_btn = QPushButton("Load constants from file")
         self._load_offset_btn = QPushButton("Load constants from file")

--- a/extra_foam/pipeline/processors/image_processor.py
+++ b/extra_foam/pipeline/processors/image_processor.py
@@ -68,8 +68,8 @@ class ImageProcessor(_BaseProcessor):
         self._correct_offset = True
         self._gain = None
         self._offset = None
-        self._gain_slicer = None
-        self._offset_slicer = None
+        self._gain_slicer = slice(None, None)
+        self._offset_slicer = slice(None, None)
         self._compute_gain_mean = False
         self._compute_offset_mean = False
         self._gain_mean = None
@@ -243,11 +243,6 @@ class ImageProcessor(_BaseProcessor):
         if self._correct_gain:
             if gain is not None:
                 sliced_gain = gain[self._gain_slicer]
-                if sliced_gain.shape != expected_shape:
-                    raise ImageProcessingError(
-                        f"[Image processor] Shape of the gain constant "
-                        f"{sliced_gain.shape} is different from the data "
-                        f"{expected_shape}")
                 if self._compute_gain_mean:
                     # For visualization of the gain
                     self._gain_mean = nanmean_image_data(sliced_gain)
@@ -256,6 +251,13 @@ class ImageProcessor(_BaseProcessor):
                 if self._compute_gain_mean:
                     self._gain_mean = None
                     self._compute_gain_mean = False
+
+            if sliced_gain is not None and \
+                    sliced_gain.shape != expected_shape:
+                raise ImageProcessingError(
+                    f"[Image processor] Shape of the gain constant "
+                    f"{sliced_gain.shape} is different from the data "
+                    f"{expected_shape}")
 
         sliced_offset = None
         if self._correct_offset:

--- a/extra_foam/pipeline/tests/__init__.py
+++ b/extra_foam/pipeline/tests/__init__.py
@@ -49,7 +49,11 @@ class _TestDataMixin:
 
         processed.image = ImageData.from_array(imgs, **kwargs)
 
-        slicer = slice(None, None) if slicer is None else slicer
+        if len(shape) == 2:
+            slicer = None
+        else:
+            slicer = slice(None, None) if slicer is None else slicer
+
         src_list = [('Foo', 'oof'), ('Bar', 'rab'), ('karaboFAI', 'extra_foam')]
         src_name, key_name = random.choice(src_list)
 

--- a/extra_foam/pipeline/tests/__init__.py
+++ b/extra_foam/pipeline/tests/__init__.py
@@ -49,7 +49,7 @@ class _TestDataMixin:
 
         processed.image = ImageData.from_array(imgs, **kwargs)
 
-        if len(shape) == 2:
+        if imgs.ndim == 2:
             slicer = None
         else:
             slicer = slice(None, None) if slicer is None else slicer
@@ -93,9 +93,12 @@ class _TestDataMixin:
             },
             'assembled': {
                 'data': imgs,
-                'sliced': imgs[slicer]
             }
         }
+        if imgs.ndim == 2:
+            data['assembled']['sliced'] = imgs
+        else:
+            data['assembled']['sliced'] = imgs[slicer]
 
         return data, processed
 


### PR DESCRIPTION
- By default, uncheck gain/offset correction;
- Improve unittest.