### PR TITLE
Regularize names of attributes and methods in special suite bases

### DIFF
--- a/extra_foam/special_suite/cam_view_proc.py
+++ b/extra_foam/special_suite/cam_view_proc.py
@@ -61,7 +61,7 @@ class CamViewProcessor(QThreadWorker):
 
     def onLoadDarkRun(self, dirpath):
         """Override."""
-        run = self._loadRunDirectory(dirpath)
+        run = self._loadRunDirectoryST(dirpath)
         if run is not None:
             try:
                 arr = run.get_array(self._output_channel, self._ppt)
@@ -89,22 +89,22 @@ class CamViewProcessor(QThreadWorker):
         """Override."""
         data, meta = data["raw"], data["meta"]
 
-        tid = self._get_tid(meta)
+        tid = self.getTrainId(meta)
 
         if not self._output_channel or not self._ppt:
             return
-        img = self._squeeze_camera_image(
-            tid, self._get_property_data(data, self._output_channel, self._ppt))
+        img = self.squeezeToImage(
+            tid, self.getPropertyData(data, self._output_channel, self._ppt))
         if img is None:
             return
 
-        if self._recording_dark:
+        if self.recordingDark():
             self._dark_ma = img
             displayed = self._dark_ma
         else:
             self._raw_ma = img
             displayed = self._raw_ma
-            if self._subtract_dark and self._dark_ma is not None:
+            if self.subtractDark() and self._dark_ma is not None:
                 # caveat: cannot subtract inplace
                 displayed = displayed - self._dark_ma
 

--- a/extra_foam/special_suite/cam_view_w.py
+++ b/extra_foam/special_suite/cam_view_w.py
@@ -102,23 +102,22 @@ class CamViewWindow(_SpecialAnalysisBase):
         right_panel = QSplitter(Qt.Vertical)
         right_panel.addWidget(self._view)
 
-        self._cw.addWidget(self._left_panel)
-        self._cw.addWidget(right_panel)
-        self._cw.setSizes(
-            [self._TOTAL_W / 4, 3 * self._TOTAL_W / 4])
+        cw = self.centralWidget()
+        cw.addWidget(right_panel)
+        cw.setSizes([self._TOTAL_W / 4, 3 * self._TOTAL_W / 4])
 
         self.resize(self._TOTAL_W, self._TOTAL_H)
 
     def initConnections(self):
         """Override."""
-        self._ctrl_widget.output_ch_le.value_changed_sgn.connect(
-            self._worker.onOutputChannelChanged)
-        self._ctrl_widget.output_ch_le.returnPressed.emit()
+        self._ctrl_widget_st.output_ch_le.value_changed_sgn.connect(
+            self._worker_st.onOutputChannelChanged)
+        self._ctrl_widget_st.output_ch_le.returnPressed.emit()
 
-        self._ctrl_widget.property_le.value_changed_sgn.connect(
-            self._worker.onPropertyChanged)
-        self._ctrl_widget.property_le.returnPressed.emit()
+        self._ctrl_widget_st.property_le.value_changed_sgn.connect(
+            self._worker_st.onPropertyChanged)
+        self._ctrl_widget_st.property_le.returnPressed.emit()
 
-        self._ctrl_widget.ma_window_le.value_changed_sgn.connect(
-            self._worker.onMaWindowChanged)
-        self._ctrl_widget.ma_window_le.returnPressed.emit()
+        self._ctrl_widget_st.ma_window_le.value_changed_sgn.connect(
+            self._worker_st.onMaWindowChanged)
+        self._ctrl_widget_st.ma_window_le.returnPressed.emit()

--- a/extra_foam/special_suite/gotthard_proc.py
+++ b/extra_foam/special_suite/gotthard_proc.py
@@ -92,7 +92,7 @@ class GotthardProcessor(QThreadWorker):
 
     def onLoadDarkRun(self, dirpath):
         """Override."""
-        run = self._loadRunDirectory(dirpath)
+        run = self._loadRunDirectoryST(dirpath)
         if run is not None:
             try:
                 arr = run.get_array(self._output_channel, self._ppt)
@@ -128,11 +128,11 @@ class GotthardProcessor(QThreadWorker):
     def process(self, data):
         """Override."""
         data, meta = data["raw"], data["meta"]
-        tid = self._get_tid(meta)
+        tid = self.getTrainId(meta)
 
         if not self._output_channel or not self._ppt:
             return
-        raw = self._get_property_data(data, self._output_channel, self._ppt)
+        raw = self.getPropertyData(data, self._output_channel, self._ppt)
 
         # check data shape
         if raw.ndim != 2:
@@ -151,7 +151,7 @@ class GotthardProcessor(QThreadWorker):
         # process data
         # ------------
 
-        if self._recording_dark:
+        if self.recordingDark():
             # update the moving average of dark data
             self._dark_ma = raw
 
@@ -166,7 +166,7 @@ class GotthardProcessor(QThreadWorker):
             # update the moving average of raw data
             self._raw_ma = raw
 
-            if self._subtract_dark and self._dark_mean_ma is not None:
+            if self.subtractDark() and self._dark_mean_ma is not None:
                 displayed = raw[self._pulse_slicer] - self._dark_mean_ma
                 displayed_ma = self._raw_ma[self._pulse_slicer] - self._dark_mean_ma
             else:

--- a/extra_foam/special_suite/gotthard_w.py
+++ b/extra_foam/special_suite/gotthard_w.py
@@ -40,7 +40,7 @@ class GotthardCtrlWidget(_BaseAnalysisCtrlWidgetS):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if self._topic == "MID":
+        if self.topic == "MID":
             default_output_ch = "MID_EXP_DES/DET/GOTTHARD_RECEIVER:daqOutput"
         else:
             default_output_ch = "Gotthard:output"
@@ -227,41 +227,40 @@ class GotthardWindow(_SpecialAnalysisBase):
         right_panel.addWidget(self._heatmap)
         right_panel.setSizes([self._TOTAL_H / 2, self._TOTAL_H / 2])
 
-        self._cw.addWidget(self._left_panel)
-        self._cw.addWidget(middle_panel)
-        self._cw.addWidget(right_panel)
-        self._cw.setSizes(
-            [self._TOTAL_W / 3, self._TOTAL_W / 3, self._TOTAL_W / 3])
+        cw = self.centralWidget()
+        cw.addWidget(middle_panel)
+        cw.addWidget(right_panel)
+        cw.setSizes([self._TOTAL_W / 3, self._TOTAL_W / 3, self._TOTAL_W / 3])
 
         self.resize(self._TOTAL_W, self._TOTAL_H)
 
     def initConnections(self):
         """Override."""
-        self._ctrl_widget.output_ch_le.value_changed_sgn.connect(
-            self._worker.onOutputChannelChanged)
-        self._ctrl_widget.output_ch_le.returnPressed.emit()
+        self._ctrl_widget_st.output_ch_le.value_changed_sgn.connect(
+            self._worker_st.onOutputChannelChanged)
+        self._ctrl_widget_st.output_ch_le.returnPressed.emit()
 
-        self._ctrl_widget.poi_index_le.value_changed_sgn.connect(
-            lambda x: self._worker.onPoiIndexChanged(int(x)))
-        self._ctrl_widget.poi_index_le.returnPressed.emit()
+        self._ctrl_widget_st.poi_index_le.value_changed_sgn.connect(
+            lambda x: self._worker_st.onPoiIndexChanged(int(x)))
+        self._ctrl_widget_st.poi_index_le.returnPressed.emit()
 
-        self._ctrl_widget.pulse_slicer_le.value_changed_sgn.connect(
-            self._worker.onPulseSlicerChanged)
-        self._ctrl_widget.pulse_slicer_le.returnPressed.emit()
+        self._ctrl_widget_st.pulse_slicer_le.value_changed_sgn.connect(
+            self._worker_st.onPulseSlicerChanged)
+        self._ctrl_widget_st.pulse_slicer_le.returnPressed.emit()
 
-        self._ctrl_widget.ma_window_le.value_changed_sgn.connect(
-            self._worker.onMaWindowChanged)
-        self._ctrl_widget.ma_window_le.returnPressed.emit()
+        self._ctrl_widget_st.ma_window_le.value_changed_sgn.connect(
+            self._worker_st.onMaWindowChanged)
+        self._ctrl_widget_st.ma_window_le.returnPressed.emit()
 
-        self._ctrl_widget.bin_range_le.value_changed_sgn.connect(
-            self._worker.onBinRangeChanged)
-        self._ctrl_widget.bin_range_le.returnPressed.emit()
+        self._ctrl_widget_st.bin_range_le.value_changed_sgn.connect(
+            self._worker_st.onBinRangeChanged)
+        self._ctrl_widget_st.bin_range_le.returnPressed.emit()
 
-        self._ctrl_widget.n_bins_le.value_changed_sgn.connect(
-            self._worker.onNoBinsChanged)
-        self._ctrl_widget.n_bins_le.returnPressed.emit()
+        self._ctrl_widget_st.n_bins_le.value_changed_sgn.connect(
+            self._worker_st.onNoBinsChanged)
+        self._ctrl_widget_st.n_bins_le.returnPressed.emit()
 
-        self._ctrl_widget.hist_over_ma_cb.toggled.connect(
-            self._worker.onHistOverMaChanged)
-        self._ctrl_widget.hist_over_ma_cb.toggled.emit(
-            self._ctrl_widget.hist_over_ma_cb.isChecked())
+        self._ctrl_widget_st.hist_over_ma_cb.toggled.connect(
+            self._worker_st.onHistOverMaChanged)
+        self._ctrl_widget_st.hist_over_ma_cb.toggled.emit(
+            self._ctrl_widget_st.hist_over_ma_cb.isChecked())

--- a/extra_foam/special_suite/module_scan_proc.py
+++ b/extra_foam/special_suite/module_scan_proc.py
@@ -32,7 +32,7 @@ class ModuleScanProcessor(QThreadWorker):
         """Override."""
         data, meta = data["raw"], data["meta"]
 
-        tid = self._get_tid(meta)
+        tid = self.getTrainId(meta)
 
         self.log.info(f"Train {tid} processed")
 

--- a/extra_foam/special_suite/module_scan_w.py
+++ b/extra_foam/special_suite/module_scan_w.py
@@ -91,10 +91,9 @@ class ModuleScanWindow(_SpecialAnalysisBase):
         right_panel = QSplitter(Qt.Vertical)
         right_panel.addWidget(self._scan_plot)
 
-        self._cw.addWidget(self._left_panel)
-        self._cw.addWidget(right_panel)
-        self._cw.setSizes(
-            [self._TOTAL_W / 4, 3 * self._TOTAL_W / 4])
+        cw = self.centralWidget()
+        cw.addWidget(right_panel)
+        cw.setSizes([self._TOTAL_W / 4, 3 * self._TOTAL_W / 4])
 
         self.resize(self._TOTAL_W, self._TOTAL_H)
 

--- a/extra_foam/special_suite/multicam_view_proc.py
+++ b/extra_foam/special_suite/multicam_view_proc.py
@@ -45,15 +45,15 @@ class MultiCamViewProcessor(QThreadWorker):
         """Override."""
         data, meta = data["raw"], data["meta"]
 
-        tid = self._get_tid(meta)
+        tid = self.getTrainId(meta)
 
         channels = {i: None for i in range(self._N_CAMERAS)}
         images = {i: None for i in range(self._N_CAMERAS)}
         for i, (ch, ppt) in enumerate(zip(self._output_channels,
                                           self._properties)):
             if ch and ppt:
-                images[i] = self._squeeze_camera_image(
-                    tid, self._get_property_data(data, ch, ppt))
+                images[i] = self.squeezeToImage(
+                    tid, self.getPropertyData(data, ch, ppt))
             else:
                 images[i] = None
             channels[i] = ch

--- a/extra_foam/special_suite/multicam_view_w.py
+++ b/extra_foam/special_suite/multicam_view_w.py
@@ -107,21 +107,20 @@ class MultiCamViewWindow(_SpecialAnalysisBase):
             right_layout.addWidget(view, i // 2, i % 2)
         right_panel.setLayout(right_layout)
 
-        self._cw.addWidget(self._left_panel)
-        self._cw.addWidget(right_panel)
-        self._cw.setSizes(
-            [self._TOTAL_W / 4, 3 * self._TOTAL_W / 4])
+        cw = self.centralWidget()
+        cw.addWidget(right_panel)
+        cw.setSizes([self._TOTAL_W / 4, 3 * self._TOTAL_W / 4])
 
         self.resize(self._TOTAL_W, self._TOTAL_H)
 
     def initConnections(self):
         """Override."""
-        for i, (ch, ppt) in enumerate(zip(self._ctrl_widget.output_channels,
-                                          self._ctrl_widget.properties)):
+        for i, (ch, ppt) in enumerate(zip(self._ctrl_widget_st.output_channels,
+                                          self._ctrl_widget_st.properties)):
             ch.value_changed_sgn.connect(
-                functools.partial(self._worker.onOutputChannelChanged, i))
+                functools.partial(self._worker_st.onOutputChannelChanged, i))
             ch.returnPressed.emit()
 
             ppt.value_changed_sgn.connect(
-                functools.partial(self._worker.onPropertyChanged, i))
+                functools.partial(self._worker_st.onPropertyChanged, i))
             ppt.returnPressed.emit()

--- a/extra_foam/special_suite/tests/test_camview.py
+++ b/extra_foam/special_suite/tests/test_camview.py
@@ -39,14 +39,14 @@ class TestCamView(unittest.TestCase):
     def testWindow(self):
         win = self._win
 
-        self.assertEqual(1, len(win._plot_widgets))
+        self.assertEqual(1, len(win._plot_widgets_st))
         counter = Counter()
-        for key in win._plot_widgets:
+        for key in win._plot_widgets_st:
             counter[key.__class__] += 1
 
         self.assertEqual(1, counter[CameraView])
 
-        win.updateWidgetsF()
+        win.updateWidgetsST()
 
     def testCtrl(self):
         from extra_foam.special_suite.cam_view_w import (
@@ -54,8 +54,8 @@ class TestCamView(unittest.TestCase):
         )
 
         win = self._win
-        ctrl_widget = win._ctrl_widget
-        proc = win._worker
+        ctrl_widget = win._ctrl_widget_st
+        proc = win._worker_st
 
         # test default values
         self.assertEqual(_DEFAULT_OUTPUT_CHANNEL, proc._output_channel)
@@ -113,7 +113,7 @@ class TestCamViewProcessor(_RawDataMixin):
             np.testing.assert_array_equal(np.ones((2, 2), dtype=np.float32),
                                           proc.process(data)['displayed'])
 
-    @patch("extra_foam.special_suite.special_analysis_base.QThreadWorker._loadRunDirectory")
+    @patch("extra_foam.special_suite.special_analysis_base.QThreadWorker._loadRunDirectoryST")
     def testLoadDarkRun(self, load_run):
         proc = self._proc
 
@@ -143,8 +143,8 @@ class TestCamViewProcessor(_RawDataMixin):
         proc = self._proc
         assert 2147483647 == proc.__class__._dark_ma.window
 
-        proc._recording_dark = True
-        proc._subtract_dark = True  # take no effect
+        proc._recording_dark_st = True
+        proc._subtract_dark_st = True  # take no effect
 
         imgdata_gt = self._img_data.astype(_IMAGE_DTYPE)
         imgdata_gt2 = 2.0 * self._img_data

--- a/extra_foam/special_suite/tests/test_gotthard.py
+++ b/extra_foam/special_suite/tests/test_gotthard.py
@@ -40,9 +40,9 @@ class TestGotthard(unittest.TestCase):
     def testWindow(self):
         win = self._win
 
-        self.assertEqual(4, len(win._plot_widgets))
+        self.assertEqual(4, len(win._plot_widgets_st))
         counter = Counter()
-        for key in win._plot_widgets:
+        for key in win._plot_widgets_st:
             counter[key.__class__] += 1
 
         self.assertEqual(1, counter[GotthardImageView])
@@ -50,7 +50,7 @@ class TestGotthard(unittest.TestCase):
         self.assertEqual(1, counter[GotthardPulsePlot])
         self.assertEqual(1, counter[GotthardHist])
 
-        win.updateWidgetsF()
+        win.updateWidgetsST()
 
     def testCtrl(self):
         from extra_foam.special_suite.gotthard_w import _DEFAULT_N_BINS, _DEFAULT_BIN_RANGE
@@ -58,8 +58,8 @@ class TestGotthard(unittest.TestCase):
         default_bin_range = tuple(float(v) for v in _DEFAULT_BIN_RANGE.split(','))
 
         win = self._win
-        ctrl_widget = win._ctrl_widget
-        proc = win._worker
+        ctrl_widget = win._ctrl_widget_st
+        proc = win._worker_st
 
         # test default values
         self.assertTrue(proc._output_channel)
@@ -156,7 +156,7 @@ class TestGotthardProcessor(_RawDataMixin):
             proc._pulse_slicer = slice(None, None, 2)
             proc.process(data)
 
-    @patch("extra_foam.special_suite.special_analysis_base.QThreadWorker._loadRunDirectory")
+    @patch("extra_foam.special_suite.special_analysis_base.QThreadWorker._loadRunDirectoryST")
     def testLoadDarkRun(self, load_run):
         proc = self._proc
 
@@ -187,8 +187,8 @@ class TestGotthardProcessor(_RawDataMixin):
 
         proc = self._proc
         assert 2147483647 == proc.__class__._dark_ma.window
-        proc._recording_dark = True
-        proc._subtract_dark = True  # take no effect
+        proc._recording_dark_st = True
+        proc._subtract_dark_st = True  # take no effect
         proc._poi_index = 0
 
         adc_gt = self._adc.astype(_PIXEL_DTYPE)

--- a/extra_foam/special_suite/tests/test_module_scan.py
+++ b/extra_foam/special_suite/tests/test_module_scan.py
@@ -33,9 +33,9 @@ class TestModuleScan(unittest.TestCase):
     def testWindow(self):
         win = self._win
 
-        self.assertEqual(1, len(win._plot_widgets))
+        self.assertEqual(1, len(win._plot_widgets_st))
         counter = Counter()
-        for key in win._plot_widgets:
+        for key in win._plot_widgets_st:
             counter[key.__class__] += 1
 
         # self.assertEqual(1, counter[GotthardImageView])
@@ -43,12 +43,12 @@ class TestModuleScan(unittest.TestCase):
         # self.assertEqual(1, counter[GotthardPulsePlot])
         # self.assertEqual(1, counter[GotthardHist])
         #
-        # win.updateWidgetsF()
+        # win.updateWidgetsST()
 
     def testCtrl(self):
         win = self._win
-        widget = win._ctrl_widget
-        proc = win._worker
+        widget = win._ctrl_widget_st
+        proc = win._worker_st
 
 
 class TestModuleScanProcessor:

--- a/extra_foam/special_suite/tests/test_multicamview.py
+++ b/extra_foam/special_suite/tests/test_multicamview.py
@@ -35,20 +35,20 @@ class TestMultiCamView(unittest.TestCase):
     def testWindow(self):
         win = self._win
 
-        self.assertEqual(4, len(win._plot_widgets))
+        self.assertEqual(4, len(win._plot_widgets_st))
         counter = Counter()
-        for key in win._plot_widgets:
+        for key in win._plot_widgets_st:
             counter[key.__class__] += 1
 
         self.assertEqual(4, counter[CameraView])
 
-        win.updateWidgetsF()
+        win.updateWidgetsST()
 
     def testCtrl(self):
 
         win = self._win
-        ctrl_widget = win._ctrl_widget
-        proc = win._worker
+        ctrl_widget = win._ctrl_widget_st
+        proc = win._worker_st
 
         # test default values
 

--- a/extra_foam/special_suite/tests/test_trxas.py
+++ b/extra_foam/special_suite/tests/test_trxas.py
@@ -36,16 +36,16 @@ class TestTrxasWindow(unittest.TestCase):
     def testWindow(self):
         win = self._win
 
-        self.assertEqual(6, len(win._plot_widgets))
+        self.assertEqual(6, len(win._plot_widgets_st))
         counter = Counter()
-        for key in win._plot_widgets:
+        for key in win._plot_widgets_st:
             counter[key.__class__] += 1
 
         self.assertEqual(3, counter[TrxasRoiImageView])
         self.assertEqual(2, counter[TrxasAbsorptionPlot])
         self.assertEqual(1, counter[TrxasHeatmap])
 
-        win.updateWidgetsF()
+        win.updateWidgetsST()
 
     def testCtrl(self):
         from extra_foam.special_suite.trxas_w import (
@@ -55,8 +55,8 @@ class TestTrxasWindow(unittest.TestCase):
         default_bin_range = tuple(float(v) for v in _DEFAULT_BIN_RANGE.split(','))
 
         win = self._win
-        ctrl_widget = win._ctrl_widget
-        proc = win._worker
+        ctrl_widget = win._ctrl_widget_st
+        proc = win._worker_st
 
         # test default values
         self.assertTupleEqual(default_bin_range, proc._delay_range)
@@ -128,7 +128,7 @@ class TestTrxasWindow(unittest.TestCase):
 
         # test reset button
         proc._reset = False
-        win.reset_sgn.emit()
+        win._onResetST()
         self.assertTrue(proc._reset)
 
     def testAbsorptionPlot(self):

--- a/extra_foam/special_suite/tests/test_xas_tim.py
+++ b/extra_foam/special_suite/tests/test_xas_tim.py
@@ -37,9 +37,9 @@ class TestXasTimWindow(unittest.TestCase):
     def testWindow(self):
         win = self._win
 
-        self.assertEqual(9, len(win._plot_widgets))
+        self.assertEqual(9, len(win._plot_widgets_st))
         counter = Counter()
-        for key in win._plot_widgets:
+        for key in win._plot_widgets_st:
             counter[key.__class__] += 1
 
         self.assertEqual(1, counter[XasTimXgmPulsePlot])
@@ -49,7 +49,7 @@ class TestXasTimWindow(unittest.TestCase):
         self.assertEqual(1, counter[XasTimAbsorpSpectraPlot])
         self.assertEqual(1, counter[XasTimXgmSpectrumPlot])
 
-        win.updateWidgetsF()
+        win.updateWidgetsST()
 
     def testCtrl(self):
         from extra_foam.special_suite.xas_tim_w import (
@@ -58,8 +58,8 @@ class TestXasTimWindow(unittest.TestCase):
         )
 
         win = self._win
-        ctrl_widget = win._ctrl_widget
-        proc = win._worker
+        ctrl_widget = win._ctrl_widget_st
+        proc = win._worker_st
 
         # test default values
         self.assertTrue(proc._xgm_output_channel)

--- a/extra_foam/special_suite/trxas_proc.py
+++ b/extra_foam/special_suite/trxas_proc.py
@@ -132,7 +132,7 @@ class TrxasProcessor(QThreadWorker, _BinMixin):
             self._energy_range = value
             self._bin2d = True
 
-    def onReset(self):
+    def reset(self):
         """Override."""
         self._reset = True
 
@@ -226,12 +226,12 @@ class TrxasProcessor(QThreadWorker, _BinMixin):
 
         if not self._delay_device or not self._delay_ppt:
             return
-        delay = self._get_property_data(
+        delay = self.getPropertyData(
             raw, self._delay_device, self._delay_ppt)
 
         if not self._energy_device or not self._energy_ppt:
             return
-        energy = self._get_property_data(
+        energy = self.getPropertyData(
             raw, self._energy_device, self._energy_ppt)
 
         return roi1, roi2, roi3, sum1, sum2, sum3, delay, energy

--- a/extra_foam/special_suite/trxas_w.py
+++ b/extra_foam/special_suite/trxas_w.py
@@ -128,7 +128,6 @@ class TrxasCtrlWidget(_BaseAnalysisCtrlWidgetS):
         self._swapLineEditContent(self._delay_ppt_le, self._energy_ppt_le)
         self._swapLineEditContent(self._delay_range_le, self._energy_range_le)
         self._swapLineEditContent(self._n_delay_bins_le, self._n_energy_bins_le)
-        self._scan_btn_set.reset_sgn.emit()
 
     def _swapLineEditContent(self, edit1, edit2):
         text1 = edit1.text()
@@ -261,44 +260,42 @@ class TrxasWindow(_SpecialAnalysisBase):
         right_panel.addWidget(self._a21_heatmap)
         right_panel.setSizes([self._TOTAL_H / 3.0] * 3)
 
-        self._cw.addWidget(self._left_panel)
-        self._cw.addWidget(middle_panel)
-        self._cw.addWidget(right_panel)
+        cw = self.centralWidget()
+        cw.addWidget(middle_panel)
+        cw.addWidget(right_panel)
 
         self.resize(self._TOTAL_W, self._TOTAL_H)
 
     def initConnections(self):
         """Override."""
-        self._ctrl_widget.delay_device_le.value_changed_sgn.connect(
-            self._worker.onDelayDeviceChanged)
-        self._ctrl_widget.delay_ppt_le.value_changed_sgn.connect(
-            self._worker.onDelayPropertyChanged)
+        self._ctrl_widget_st.delay_device_le.value_changed_sgn.connect(
+            self._worker_st.onDelayDeviceChanged)
+        self._ctrl_widget_st.delay_ppt_le.value_changed_sgn.connect(
+            self._worker_st.onDelayPropertyChanged)
 
-        self._ctrl_widget.delay_device_le.returnPressed.emit()
-        self._ctrl_widget.delay_ppt_le.returnPressed.emit()
+        self._ctrl_widget_st.delay_device_le.returnPressed.emit()
+        self._ctrl_widget_st.delay_ppt_le.returnPressed.emit()
 
-        self._ctrl_widget.energy_device_le.value_changed_sgn.connect(
-            self._worker.onEnergyDeviceChanged)
-        self._ctrl_widget.energy_ppt_le.value_changed_sgn.connect(
-            self._worker.onEnergyPropertyChanged)
+        self._ctrl_widget_st.energy_device_le.value_changed_sgn.connect(
+            self._worker_st.onEnergyDeviceChanged)
+        self._ctrl_widget_st.energy_ppt_le.value_changed_sgn.connect(
+            self._worker_st.onEnergyPropertyChanged)
 
-        self._ctrl_widget.energy_device_le.returnPressed.emit()
-        self._ctrl_widget.energy_ppt_le.returnPressed.emit()
+        self._ctrl_widget_st.energy_device_le.returnPressed.emit()
+        self._ctrl_widget_st.energy_ppt_le.returnPressed.emit()
 
-        self._ctrl_widget.n_delay_bins_le.value_changed_sgn.connect(
-            self._worker.onNoDelayBinsChanged)
-        self._ctrl_widget.delay_range_le.value_changed_sgn.connect(
-            self._worker.onDelayRangeChanged)
+        self._ctrl_widget_st.n_delay_bins_le.value_changed_sgn.connect(
+            self._worker_st.onNoDelayBinsChanged)
+        self._ctrl_widget_st.delay_range_le.value_changed_sgn.connect(
+            self._worker_st.onDelayRangeChanged)
 
-        self._ctrl_widget.n_delay_bins_le.returnPressed.emit()
-        self._ctrl_widget.delay_range_le.returnPressed.emit()
+        self._ctrl_widget_st.n_delay_bins_le.returnPressed.emit()
+        self._ctrl_widget_st.delay_range_le.returnPressed.emit()
 
-        self._ctrl_widget.n_energy_bins_le.value_changed_sgn.connect(
-            self._worker.onNoEnergyBinsChanged)
-        self._ctrl_widget.energy_range_le.value_changed_sgn.connect(
-            self._worker.onEnergyRangeChanged)
+        self._ctrl_widget_st.n_energy_bins_le.value_changed_sgn.connect(
+            self._worker_st.onNoEnergyBinsChanged)
+        self._ctrl_widget_st.energy_range_le.value_changed_sgn.connect(
+            self._worker_st.onEnergyRangeChanged)
 
-        self._ctrl_widget.n_energy_bins_le.returnPressed.emit()
-        self._ctrl_widget.energy_range_le.returnPressed.emit()
-
-        self.reset_sgn.connect(self._worker.onReset)
+        self._ctrl_widget_st.n_energy_bins_le.returnPressed.emit()
+        self._ctrl_widget_st.energy_range_le.returnPressed.emit()

--- a/extra_foam/special_suite/xas_tim_proc.py
+++ b/extra_foam/special_suite/xas_tim_proc.py
@@ -132,24 +132,24 @@ class XasTimProcessor(QThreadWorker):
         """Override."""
         data, meta = data["raw"], data["meta"]
 
-        tid = self._get_tid(meta)
+        tid = self.getTrainId(meta)
 
         if not self._xgm_output_channel:
             return
-        xgm_intensity = self._get_property_data(
+        xgm_intensity = self.getPropertyData(
             data, self._xgm_output_channel, self._xgm_ppt)
 
         if not self._digitizer_output_channel:
             return
         digitizer_apds = []
         for i, ppt in enumerate(self._digitizer_ppts):
-            apd = self._get_property_data(
+            apd = self.getPropertyData(
                 data, self._digitizer_output_channel, ppt)
             digitizer_apds.append(apd)
 
         if not self._mono_device_id:
             return
-        energy = self._get_property_data(
+        energy = self.getPropertyData(
             data, self._mono_device_id, self._mono_ppt)
 
         # check and slice XGM intensity
@@ -221,7 +221,7 @@ class XasTimProcessor(QThreadWorker):
             "spectra": (stats, centers, counts),
         }
 
-    def onReset(self):
+    def reset(self):
         """Override."""
         self._i0.reset()
         for q in self._i1:

--- a/extra_foam/special_suite/xas_tim_w.py
+++ b/extra_foam/special_suite/xas_tim_w.py
@@ -287,6 +287,7 @@ class XasTimWindow(_SpecialAnalysisBase):
         self.startWorker()
 
     def initUI(self):
+        """Override."""
         right_panel = QTabWidget()
 
         right_panel1 = QSplitter(Qt.Vertical)
@@ -309,50 +310,51 @@ class XasTimWindow(_SpecialAnalysisBase):
         right_panel.addTab(right_panel2, "Correlation and spectra")
         right_panel.setTabPosition(QTabWidget.TabPosition.South)
 
-        self._cw.addWidget(self._left_panel)
-        self._cw.addWidget(right_panel)
-        self._cw.setSizes([self._TOTAL_W / 4, 3 * self._TOTAL_W / 4])
+        cw = self.centralWidget()
+        cw.addWidget(right_panel)
+        cw.setSizes([self._TOTAL_W / 4, 3 * self._TOTAL_W / 4])
 
         self.resize(self._TOTAL_W, self._TOTAL_H)
 
     def initConnections(self):
-        self._ctrl_widget.xgm_output_ch_le.value_changed_sgn.connect(
-            self._worker.onXgmOutputChannelChanged)
-        self._ctrl_widget.xgm_output_ch_le.returnPressed.emit()
+        """Override."""
+        self._ctrl_widget_st.xgm_output_ch_le.value_changed_sgn.connect(
+            self._worker_st.onXgmOutputChannelChanged)
+        self._ctrl_widget_st.xgm_output_ch_le.returnPressed.emit()
 
-        self._ctrl_widget.digitizer_output_ch_le.value_changed_sgn.connect(
-            self._worker.onDigitizerOutputChannelChanged)
-        self._ctrl_widget.digitizer_output_ch_le.returnPressed.emit()
+        self._ctrl_widget_st.digitizer_output_ch_le.value_changed_sgn.connect(
+            self._worker_st.onDigitizerOutputChannelChanged)
+        self._ctrl_widget_st.digitizer_output_ch_le.returnPressed.emit()
 
-        self._ctrl_widget.mono_device_le.value_changed_sgn.connect(
-            self._worker.onMonoDeviceChanged)
-        self._ctrl_widget.mono_device_le.returnPressed.emit()
+        self._ctrl_widget_st.mono_device_le.value_changed_sgn.connect(
+            self._worker_st.onMonoDeviceChanged)
+        self._ctrl_widget_st.mono_device_le.returnPressed.emit()
 
-        self._ctrl_widget.n_pulses_per_train_le.value_changed_sgn.connect(
-            self._worker.onNPulsesPerTrainChanged)
-        self._ctrl_widget.n_pulses_per_train_le.returnPressed.emit()
+        self._ctrl_widget_st.n_pulses_per_train_le.value_changed_sgn.connect(
+            self._worker_st.onNPulsesPerTrainChanged)
+        self._ctrl_widget_st.n_pulses_per_train_le.returnPressed.emit()
 
-        self._ctrl_widget.apd_stride_le.value_changed_sgn.connect(
-            self._worker.onApdStrideChanged)
-        self._ctrl_widget.apd_stride_le.returnPressed.emit()
+        self._ctrl_widget_st.apd_stride_le.value_changed_sgn.connect(
+            self._worker_st.onApdStrideChanged)
+        self._ctrl_widget_st.apd_stride_le.returnPressed.emit()
 
-        for i, cb in enumerate(self._ctrl_widget.spectra_displayed):
+        for i, cb in enumerate(self._ctrl_widget_st.spectra_displayed):
             cb.toggled.connect(
-                partial(self._worker.onSpectraDisplayedChanged, i))
+                partial(self._worker_st.onSpectraDisplayedChanged, i))
             cb.toggled.emit(cb.isChecked())
 
-        self._ctrl_widget.xgm_threshold_le.value_changed_sgn.connect(
-            self._worker.onXgmThresholdChanged)
-        self._ctrl_widget.xgm_threshold_le.returnPressed.emit()
+        self._ctrl_widget_st.xgm_threshold_le.value_changed_sgn.connect(
+            self._worker_st.onXgmThresholdChanged)
+        self._ctrl_widget_st.xgm_threshold_le.returnPressed.emit()
 
-        self._ctrl_widget.pulse_window_le.value_changed_sgn.connect(
-            self._worker.onPulseWindowChanged)
-        self._ctrl_widget.pulse_window_le.returnPressed.emit()
+        self._ctrl_widget_st.pulse_window_le.value_changed_sgn.connect(
+            self._worker_st.onPulseWindowChanged)
+        self._ctrl_widget_st.pulse_window_le.returnPressed.emit()
 
-        self._ctrl_widget.correlation_window_le.value_changed_sgn.connect(
-            self._worker.onCorrelationWindowChanged)
-        self._ctrl_widget.correlation_window_le.returnPressed.emit()
+        self._ctrl_widget_st.correlation_window_le.value_changed_sgn.connect(
+            self._worker_st.onCorrelationWindowChanged)
+        self._ctrl_widget_st.correlation_window_le.returnPressed.emit()
 
-        self._ctrl_widget.n_bins_le.value_changed_sgn.connect(
-            self._worker.onNoBinsChanged)
-        self._ctrl_widget.n_bins_le.returnPressed.emit()
+        self._ctrl_widget_st.n_bins_le.value_changed_sgn.connect(
+            self._worker_st.onNoBinsChanged)
+        self._ctrl_widget_st.n_bins_le.returnPressed.emit()


### PR DESCRIPTION
As apps in special suite will be programmable by scientists, it is necessary to regularize all the names to avoid naming conflict.