### PR TITLE
WIP: Moving average across trains and intra-dark offset correction

### DIFF
--- a/extra_foam/algorithms/imageproc_py.py
+++ b/extra_foam/algorithms/imageproc_py.py
@@ -12,7 +12,8 @@ import numpy as np
 from .imageproc import (
     nanmeanImageArray, movingAvgImageData,
     imageDataNanMask, maskImageDataNan, maskImageDataZero,
-    correctGain, correctOffset, correctGainOffset
+    correctGain, correctOffset, correctGainOffset,
+    correctIntraDarkOffset
 )
 
 
@@ -35,7 +36,7 @@ def nanmean_image_data(data, *, kept=None):
     return nanmeanImageArray(data, kept)
 
 
-def correct_image_data(data, *, gain=None, offset=None):
+def correct_image_data(data, *, gain=None, offset=None, intradark=False):
     """Apply gain and/or offset correct to image data.
 
     :param numpy.array data: image data, Shape = (y, x) or (indices, y, x)
@@ -43,9 +44,13 @@ def correct_image_data(data, *, gain=None, offset=None):
         shape as the image data.
     :param None/numpy.array offset: offset constants, which has the same
         shape as the image data.
+    :param bool intradark: temporary flag to use subsequent frames as
+        background, only in combination with pure offset correction.
     """
     if gain is not None and offset is not None:
         correctGainOffset(data, gain, offset)
+    elif offset is not None and intradark:
+        correctIntraDarkOffset(data, offset)
     elif offset is not None:
         correctOffset(data, offset)
     elif gain is not None:

--- a/extra_foam/gui/ctrl_widgets/image_ctrl_widget.py
+++ b/extra_foam/gui/ctrl_widgets/image_ctrl_widget.py
@@ -34,7 +34,6 @@ class ImageCtrlWidget(_AbstractCtrlWidget):
         validator.setBottom(1)
         self.moving_avg_le.setValidator(validator)
         self.moving_avg_le.setMinimumWidth(60)
-        self.moving_avg_le.setEnabled(False)
 
         self.auto_level_btn = QPushButton("Auto level")
         self.save_image_btn = QPushButton("Save image")
@@ -71,6 +70,9 @@ class ImageCtrlWidget(_AbstractCtrlWidget):
     def initConnections(self):
         """Override."""
         mediator = self._mediator
+
+        self.moving_avg_le.value_changed_sgn.connect(
+            mediator.onItMaWindowChange)
 
         self.auto_update_cb.toggled.connect(
             lambda: self.update_image_btn.setEnabled(

--- a/extra_foam/gui/mediator.py
+++ b/extra_foam/gui/mediator.py
@@ -83,6 +83,9 @@ class Mediator(QObject):
     def onCalOffsetCorrection(self, value: bool):
         self._meta.hset(mt.IMAGE_PROC, "correct_offset", str(value))
 
+    def onCalIntradarkCorrection(self, value: bool):
+        self._meta.hset(mt.IMAGE_PROC, "correct_intradark", str(value))
+
     def onCalGainMemoCellsChange(self, value: list):
         self._meta.hset(mt.IMAGE_PROC, "gain_cells", str(value))
 

--- a/src/extra_foam/f_imageproc.cpp
+++ b/src/extra_foam/f_imageproc.cpp
@@ -171,6 +171,15 @@ PYBIND11_MODULE(imageproc, m)
   // gain / offset correction
   //
 
+#define FOAM_CORRECT_INTRADARKOFFSET_IMPL(VALUE_TYPE, N_DIM)                                \
+  m.def("correctIntraDarkOffset",                                                           \
+    (void (*)(xt::pytensor<VALUE_TYPE, N_DIM>&, const xt::pytensor<VALUE_TYPE, N_DIM>&))    \
+    &correctIntraDarkImageData<IntraDarkOffsetPolicy, xt::pytensor<VALUE_TYPE, N_DIM>>,              \
+    py::arg("src").noconvert(), py::arg("offset").noconvert());
+
+  FOAM_CORRECT_INTRADARKOFFSET_IMPL(double, 3)
+  FOAM_CORRECT_INTRADARKOFFSET_IMPL(float, 3)
+
 #define FOAM_CORRECT_OFFSET_IMPL(VALUE_TYPE, N_DIM)                                         \
   m.def("correctOffset",                                                                    \
     (void (*)(xt::pytensor<VALUE_TYPE, N_DIM>&, const xt::pytensor<VALUE_TYPE, N_DIM>&))    \

--- a/src/extra_foam/include/f_imageproc.hpp
+++ b/src/extra_foam/include/f_imageproc.hpp
@@ -973,6 +973,11 @@ class IntraDarkOffsetPolicy {
 public:
   template<typename T>
   static T correct(T Xi, T Di, T Xj, T Dj) {
+    // 256 bug in DSSC where pixel with value
+    // 256 are sometimes returned as 0 instead
+    Xi = Xi ? Xi : (T)256;
+    Xj = Xj ? Xj : (T)256;
+    
     return (Xi - Di) - (Xj - Dj);
   }
 };


### PR DESCRIPTION
This PR is not meant to be merged into master, but for any discussion related to a temporary implementation for requirements expressed in https://in.xfel.eu/redmine/issues/72646. These are needed for p2599 and p2471 in the beginning of October.

- The moving average uses the infrastructure in place for feature extraction and simply switches the data taken from the `ImageData` model in `ImageAnalysis` from `masked_mean` to `masked_mean_ma`. Said widget adds a checkbox to its context menus to toggle this behaviour. The control of the moving average window uses the existing metadata, which is also wired up to the existing image tool's input element (which has been a placeholder so far).
As `ImageAnalysis` is only used in the "Overview" so far, this has no effect on the visualizations in the "Gain/offset" tab. If necessary, the implementation could be moved to `ImageViewF` instead.

- The intradark offset correction is based on Loic's previous work here https://github.com/leguyader/EXtra-foam/commit/b903647621608d48a60e002ab70930073861d9d0. While the integration is not optimal, more refactoring would be needed to process data both with and without POI in `ImageProcessor` right now. A checkbox is added to the "Gain/offset" tab to toggle this new correction, which is mutually exclusive with any other correction. This is enforced for offset, but not gain currently.

* I've also cherry-picked a "fix" related to DSSC data values (https://github.com/leguyader/EXtra-foam/commit/b4afa99b73b1f0c05adac8881026da16b5129410). 

@ebadkamil