### PR TITLE
Add initial support for saving and restoring sessions

### DIFF
--- a/docs/main_gui.rst
+++ b/docs/main_gui.rst
@@ -172,7 +172,10 @@ Define analysis parameters used globally.
 +----------------------------+--------------------------------------------------------------------+
 | ``Reset``                  | Reset the moving average counts of all registered analysis types.  |
 +----------------------------+--------------------------------------------------------------------+
-
+| ``Restore last session``   | Restore settings from the last EXtra-foam run. Currently this only |
+|                            | supports restoring the ROIs, other settings may be supported in    |
+|                            | the future.                                                        |
++----------------------------+--------------------------------------------------------------------+
 
 .. Warning::
 

--- a/extra_foam/gui/ctrl_widgets/analysis_ctrl_widget.py
+++ b/extra_foam/gui/ctrl_widgets/analysis_ctrl_widget.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import QGridLayout, QLabel, QPushButton, QWidget
 
 from .base_ctrl_widgets import _AbstractGroupBoxCtrlWidget
 from .smart_widgets import SmartLineEdit
-from ...config import config
+from ...config import config, session
 from ...database import Metadata as mt
 
 
@@ -43,6 +43,10 @@ class AnalysisCtrlWidget(_AbstractGroupBoxCtrlWidget):
         self._reset_binning_btn = QPushButton("Reset binning")
         self._reset_histogram_btn = QPushButton("Reset histogram")
 
+        self._restore_session_btn = QPushButton("Restore last session")
+        self._restore_session_btn.setToolTip("Note: this currently only restores ROIs")
+        self._restore_session_btn.setEnabled(session.can_restore())
+
         self.initUI()
         self.initConnections()
 
@@ -70,6 +74,9 @@ class AnalysisCtrlWidget(_AbstractGroupBoxCtrlWidget):
         layout.addWidget(self._reset_histogram_btn, row + 1, 2)
         layout.addWidget(self._reset_binning_btn, row + 2, 2)
 
+        row += 3
+        layout.addWidget(self._restore_session_btn, row, 0)
+
         self.setLayout(layout)
 
     def initConnections(self):
@@ -94,6 +101,9 @@ class AnalysisCtrlWidget(_AbstractGroupBoxCtrlWidget):
         self._reset_correlation_btn.clicked.connect(mediator.onCorrelationReset)
         self._reset_binning_btn.clicked.connect(mediator.onBinReset)
         self._reset_histogram_btn.clicked.connect(mediator.onHistReset)
+
+        self._restore_session_btn.clicked.connect(session.trigger_restore)
+        self._restore_session_btn.clicked.connect(lambda: self._restore_session_btn.setEnabled(False))
 
     def updateMetaData(self):
         """Override"""

--- a/extra_foam/gui/ctrl_widgets/roi_ctrl_widget.py
+++ b/extra_foam/gui/ctrl_widgets/roi_ctrl_widget.py
@@ -101,6 +101,10 @@ class _SingleRoiCtrlWidget(QWidget):
     def setLabel(self, text):
         self._activate_cb.setText(text)
 
+    @property
+    def idx(self):
+        return self._roi.index
+
     @pyqtSlot(int)
     def onToggleRoiActivation(self, state):
         if state == Qt.Checked:
@@ -113,7 +117,7 @@ class _SingleRoiCtrlWidget(QWidget):
         x, y = [int(v) for v in self._roi.pos()]
         w, h = [int(v) for v in self._roi.size()]
         self.roi_geometry_change_sgn.emit(
-            (self._roi.index, state == Qt.Checked, 0, x, y, w, h))
+            (self.idx, state == Qt.Checked, 0, x, y, w, h))
 
     @pyqtSlot(object)
     def onRoiPositionEdited(self, value):
@@ -135,7 +139,7 @@ class _SingleRoiCtrlWidget(QWidget):
 
         state = self._activate_cb.isChecked()
         self.roi_geometry_change_sgn.emit(
-            (self._roi.index, state, 0, x, y, w, h))
+            (self.idx, state, 0, x, y, w, h))
 
     @pyqtSlot(object)
     def onRoiSizeEdited(self, value):
@@ -155,7 +159,7 @@ class _SingleRoiCtrlWidget(QWidget):
         self._roi.stateChanged(finish=False)
 
         self.roi_geometry_change_sgn.emit(
-            (self._roi.index, self._activate_cb.isChecked(), 0, x, y, w, h))
+            (self.idx, self._activate_cb.isChecked(), 0, x, y, w, h))
 
     @pyqtSlot(object)
     def onRoiGeometryChangeFinished(self, roi):

--- a/extra_foam/gui/ctrl_widgets/roi_ctrl_widget.py
+++ b/extra_foam/gui/ctrl_widgets/roi_ctrl_widget.py
@@ -17,7 +17,7 @@ from ..plot_widgets import RectROI
 from ..ctrl_widgets import _AbstractCtrlWidget, SmartLineEdit
 from ..misc_widgets import FColor
 from ...database import Metadata as mt
-from ...config import config
+from ...config import config, session
 
 
 class _SingleRoiCtrlWidget(QWidget):
@@ -231,7 +231,7 @@ class RoiCtrlWidget(_AbstractCtrlWidget):
 
     def initConnections(self):
         """Override."""
-        pass
+        session.restore_session_sgn.connect(self._restoreFromSession)
 
     def updateMetaData(self):
         """Override."""
@@ -256,3 +256,10 @@ class RoiCtrlWidget(_AbstractCtrlWidget):
             layout.addWidget(widget)
         layout.setContentsMargins(1, 1, 1, 1)
         self.setLayout(layout)
+
+    @pyqtSlot()
+    def _restoreFromSession(self):
+        for ctrl in self._roi_ctrls:
+            key = f"roi-{ctrl.idx}"
+            if session.contains(key):
+                ctrl.updateParameters(*session.value(key))

--- a/extra_foam/gui/mediator.py
+++ b/extra_foam/gui/mediator.py
@@ -14,6 +14,7 @@ from PyQt5.QtCore import pyqtSignal,  QObject
 
 from ..database import Metadata as mt
 from ..database import MetaProxy
+from ..config import session
 
 
 class Mediator(QObject):
@@ -214,6 +215,8 @@ class Mediator(QObject):
 
     def onRoiGeometryChange(self, value: tuple):
         idx, activated, locked, x, y, w, h = value
+
+        session.setValue(f"roi-{idx}", (x, y, w, h))
         self._meta.hset(mt.ROI_PROC, f'geom{idx}',
                         str((int(activated), int(locked), x, y, w, h)))
 


### PR DESCRIPTION
This has been requested because sometimes extra-foam will crash (particularly on
long-running instances) and the users will lose all settings they've set. These
can be very tedious and error-prone to redo, hence the desire to restore the
settings from the previous session.

Doing this for _all_ settings in extra-foam is a huge amount of work, so this
initial implementation only supports restoring the ROIs, which is one of the
more important settings.

(P.S., anyone else, feel free to add yourself as reviewer :) )