### PR TITLE
Record and save reference over multiple trains

### DIFF
--- a/docs/image_tool.rst
+++ b/docs/image_tool.rst
@@ -252,6 +252,12 @@ Reference image
 |                              | reference image is used as a stationary off-image in the           |
 |                              | *predefined off* mode in *pump-probe* analysis.                    |
 +------------------------------+--------------------------------------------------------------------+
+| ``Record reference``         | Record the received displayed images and perform a moving average  |
+|                              | until the ``Stop`` (recording) button has been toggled.            |
+|                              | The resulting image will be set as a reference image.              |
++------------------------------+--------------------------------------------------------------------+
+| ``Save reference``           | Saves the reference image to a `NumPy` file.                       |
++------------------------------+--------------------------------------------------------------------+
 | ``Remove reference``         | Remove the reference image.                                        |
 +------------------------------+--------------------------------------------------------------------+
 

--- a/extra_foam/gui/ctrl_widgets/ref_image_ctrl_widget.py
+++ b/extra_foam/gui/ctrl_widgets/ref_image_ctrl_widget.py
@@ -7,7 +7,10 @@ Author: Jun Zhu <jun.zhu@xfel.eu>
 Copyright (C) European X-Ray Free-Electron Laser Facility GmbH.
 All rights reserved.
 """
-from PyQt5.QtWidgets import QGridLayout, QLineEdit, QPushButton
+from PyQt5.QtCore import pyqtSlot
+from PyQt5.QtWidgets import (
+    QGridLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton, QSizePolicy,
+    QSpacerItem, QWidget)
 
 from ..ctrl_widgets import _AbstractCtrlWidget
 from ..gui_helpers import create_icon_button
@@ -26,6 +29,14 @@ class RefImageCtrlWidget(_AbstractCtrlWidget):
 
         self.set_current_btn = QPushButton("Set current as reference")
 
+        # Record
+        self.record_label = QLabel()
+        self.record_label.setFixedWidth(430)
+        self.record_btn = QPushButton("Record")
+        self.record_btn.setCheckable(True)
+        self.save_btn = QPushButton("Save")
+        self.save_btn.setDisabled(True)
+
         self._non_reconfigurable_widgets = [
             self.load_btn
         ]
@@ -43,11 +54,30 @@ class RefImageCtrlWidget(_AbstractCtrlWidget):
 
         layout.addWidget(self.set_current_btn, 1, 0)
 
+        # Add widgets for recording reference
+        spacer = QSpacerItem(0, 0, QSizePolicy.Expanding)
+        record_layout = QHBoxLayout()
+        record_layout.setContentsMargins(0, 0, 0, 0)
+        record_layout.addSpacerItem(spacer)
+        record_layout.addWidget(self.record_label)
+        record_layout.addWidget(self.record_btn)
+        record_layout.addWidget(self.save_btn)
+        widget = QWidget()
+        widget.setLayout(record_layout)
+        layout.addWidget(widget, 1, 1)
+
         self.setLayout(layout)
 
     def initConnections(self):
-        """Override."""
-        pass
+        self.record_btn.toggled.connect(self._enableButtonsOnRecord)
+
+    def onStart(self):
+        super().onStart()
+        self.record_btn.setEnabled(True)
+
+    def onStop(self):
+        super().onStop()
+        self.record_btn.setEnabled(False)
 
     def updateMetaData(self):
         """Override."""
@@ -56,3 +86,12 @@ class RefImageCtrlWidget(_AbstractCtrlWidget):
     def loadMetaData(self):
         """Override."""
         pass
+
+    @pyqtSlot(bool)
+    def _enableButtonsOnRecord(self, is_recording):
+        # Disable/enable buttons when (not) recording
+        self.save_btn.setDisabled(is_recording)
+        self.set_current_btn.setDisabled(is_recording)
+
+        # Update record button text
+        self.record_btn.setText("Stop" if is_recording else "Record")

--- a/extra_foam/gui/image_tool/reference_view.py
+++ b/extra_foam/gui/image_tool/reference_view.py
@@ -9,17 +9,22 @@ All rights reserved.
 """
 import os
 import os.path as osp
+import shutil
 
+import numpy as np
 from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtWidgets import QFileDialog, QGridLayout
 
 from .base_view import _AbstractImageToolView, create_imagetool_view
 from ..ctrl_widgets import RefImageCtrlWidget
 from ..plot_widgets import ImageViewF
+from ...algorithms import movingAvgImageData
 from ...file_io import write_image
 from ...ipc import ReferencePub
 from ...logger import logger
 from ... import ROOT_PATH
+
+REFERENCE_FILE = osp.join(ROOT_PATH, "tmp", ".reference.npy")
 
 
 @create_imagetool_view(RefImageCtrlWidget)
@@ -39,6 +44,10 @@ class ReferenceView(_AbstractImageToolView):
 
         self._pub = ReferencePub()
 
+        self._is_recording = False
+        self._recorded_image = None
+        self._count = 0
+
         self.initUI()
         self.initConnections()
 
@@ -54,8 +63,11 @@ class ReferenceView(_AbstractImageToolView):
     def initConnections(self):
         """Override."""
         self._ctrl_widget.load_btn.clicked.connect(self._loadReference)
-        self._ctrl_widget.set_current_btn.clicked.connect(self._setReference)
+        self._ctrl_widget.set_current_btn.clicked.connect(
+            self._setCurrentAsReference)
         self._ctrl_widget.remove_btn.clicked.connect(self._removeReference)
+        self._ctrl_widget.record_btn.toggled.connect(self._recordReference)
+        self._ctrl_widget.save_btn.clicked.connect(self._saveReference)
 
     def updateF(self, data, auto_update):
         """Override."""
@@ -64,6 +76,20 @@ class ReferenceView(_AbstractImageToolView):
             # Removing and displaying of the currently displayed image
             # is deferred.
             self._reference.setImage(data.image.reference)
+
+        if self._is_recording:
+            self._count += 1
+            # Update cached image and count
+            image = self._corrected.image
+            if self._recorded_image is None:
+                self._recorded_image = image.copy()
+            else:
+                # Average without storing images
+                movingAvgImageData(self._recorded_image, image, self._count)
+
+            # Update status display
+            status = f"Recording..\t\tUsed trains: {self._count}"
+            self._ctrl_widget.record_label.setText(status)
 
     @pyqtSlot()
     def _loadReference(self):
@@ -76,26 +102,106 @@ class ReferenceView(_AbstractImageToolView):
         if filepath:
             self._pub.set(filepath)
             self._ctrl_widget.filepath_le.setText(filepath)
+            self._ctrl_widget.save_btn.setDisabled(True)
+            # Update label
+            text = "The loaded file has been applied as reference."
+            self._ctrl_widget.record_label.setText(text)
 
     @pyqtSlot()
-    def _setReference(self):
+    def _setCurrentAsReference(self):
         """Set the current corrected image as reference."""
-        img = self._corrected.image
-        if img is not None:
-            filepath = osp.join(ROOT_PATH, "tmp", ".reference.npy")
-            if not osp.exists(osp.dirname(filepath)):
-                os.mkdir(osp.dirname(filepath))
+        image = self._corrected.image
+        if image is not None:
+            self._writeTempReferenceFile(image)
+            if self._checkReferenceFile():
+                self._setReference(REFERENCE_FILE)
+                # Update label
+                text = "The current image has been applied as reference."
+                self._ctrl_widget.record_label.setText(text)
 
-            try:
-                write_image(filepath, img)
-            except ValueError as e:
-                logger.error(str(e))
+    def _writeTempReferenceFile(self, image):
+        """Save the input image as a reference file (.npy).
+           Path is `REFERENCE_FILE`"""
+        if image is None:
+            return
 
-            self._pub.set(filepath)
-            self._ctrl_widget.filepath_le.setText(filepath)
+        os.makedirs(osp.dirname(REFERENCE_FILE), exist_ok=True)
+
+        try:
+            write_image(REFERENCE_FILE, image)
+        except ValueError as e:
+            logger.error(str(e))
+            # Remove previous reference file
+            if osp.exists(REFERENCE_FILE):
+                os.remove(REFERENCE_FILE)
+
+    def _setReference(self, path):
+        """Sets the input image as reference"""
+        self._pub.set(path)
+        self._ctrl_widget.filepath_le.setText(path)
 
     @pyqtSlot()
     def _removeReference(self):
         """Remove the reference image."""
-        self._pub.set("")
-        self._ctrl_widget.filepath_le.setText("")
+        self._setReference("")
+        self._ctrl_widget.record_label.setText("")
+
+    @pyqtSlot(bool)
+    def _recordReference(self, is_recording):
+        """Start/stop the recording of the reference file.
+
+           When starting, a flag will be set for the `updateF()` to detect the
+           start of the image averaging of the received data.
+           Upon finishing, the recorded image is written as reference file.
+        """
+        self._is_recording = is_recording
+
+        # Log recording status
+        status = "started" if is_recording else "finished"
+        logger.info(f"Recording reference has {status}.")
+
+        if is_recording:
+            # Remove existing reference file
+            self._removeReference()
+        elif self._recorded_image is not None:
+            # Save recording to a temp file upon finishing
+            self._writeTempReferenceFile(self._recorded_image)
+            if self._checkReferenceFile():
+                self._setReference(REFERENCE_FILE)
+
+            # Reset widget and variables
+            self._recorded_image = None
+            self._count = 0
+
+            # Update label
+            text = ("The average of recorded trains "
+                    "has been applied as reference.")
+            self._ctrl_widget.record_label.setText(text)
+
+    @pyqtSlot()
+    def _saveReference(self):
+        """'Save' the reference file on the user supplied path by conveniently
+            copying the existing file to the desired path."""
+        if not self._checkReferenceFile():
+            return
+
+        filepath = QFileDialog.getSaveFileName(
+            caption="Save image",
+            directory=osp.expanduser("~"),
+            filter="NumPy Binary File (*.npy)")[0]
+
+        # Validate filepath
+        if not filepath:
+            return
+        if not filepath.lower().endswith(".npy"):
+            filepath += ".npy"
+
+        # Copy reference file from tmp folder to desired destination
+        os.makedirs(osp.dirname(filepath), exist_ok=True)
+        shutil.copyfile(REFERENCE_FILE, filepath)
+
+    def _checkReferenceFile(self, path=REFERENCE_FILE):
+        """Check if the reference file exists."""
+        exists = osp.exists(path)
+        self._ctrl_widget.save_btn.setDisabled(not exists)
+        return exists


### PR DESCRIPTION
![Screenshot from 2021-04-30 17-57-50](https://user-images.githubusercontent.com/65474471/116721489-a5d50600-a9dd-11eb-81d8-c9744744c1e9.png)

This feature enables recording reference over multiple trains. This also includes saving the reference file on a specified directory. As the reference file is already saved in the temp folder, we just copy it to the input path.

It is requested by SPB and is mentioned on #295.