### PR TITLE
Minor fixes/utils

### DIFF
--- a/extra_foam/algorithms/imageproc_py.py
+++ b/extra_foam/algorithms/imageproc_py.py
@@ -7,8 +7,6 @@ Author: Jun Zhu <jun.zhu@xfel.eu>, Ebad Kamil <ebad.kamil@xfel.eu>
 Copyright (C) European X-Ray Free-Electron Laser Facility GmbH.
 All rights reserved.
 """
-import numpy as np
-
 from .imageproc import (
     nanmeanImageArray, movingAvgImageData,
     imageDataNanMask, maskImageDataNan, maskImageDataZero,
@@ -102,7 +100,7 @@ def mask_image_data(arr, *,
         if arr.ndim == 3:
             raise ValueError("'arr' must be 2D when 'out' is specified!")
 
-        if out.dtype != np.bool:
+        if out.dtype != bool:
             raise ValueError("Type of 'out' must be bool!")
 
         if image_mask is None:

--- a/extra_foam/algorithms/tests/test_image_proc.py
+++ b/extra_foam/algorithms/tests/test_image_proc.py
@@ -316,14 +316,14 @@ class TestMaskImageData:
 
         # image mask
         img = np.array([[1, np.nan, np.nan], [3, 4, 5]], dtype=dtype)
-        img_mask = np.array([[1, 1, 0], [1, 0, 1]], dtype=np.bool)
+        img_mask = np.array([[1, 1, 0], [1, 0, 1]], dtype=bool)
         mask_image_data(img, image_mask=img_mask, keep_nan=keep_nan)
         np.testing.assert_array_equal(
             np.array([[mt, mt, mt], [mt, 4, mt]], dtype=np.float32), img)
 
         # both masks
         img = np.array([[1, np.nan, np.nan], [3, 4, 5]], dtype=dtype)
-        img_mask = np.array([[1, 1, 0], [1, 0, 1]], dtype=np.bool)
+        img_mask = np.array([[1, 1, 0], [1, 0, 1]], dtype=bool)
         mask_image_data(img, image_mask=img_mask, threshold_mask=(2, 3), keep_nan=keep_nan)
         np.testing.assert_array_equal(
             np.array([[mt, mt, mt], [mt, mt, mt]], dtype=np.float32), img)
@@ -349,8 +349,8 @@ class TestMaskImageData:
         # image mask
         img = np.array([[[1, 2, 3], [3, np.nan, np.nan]],
                         [[1, 2, 3], [3, np.nan, np.nan]]], dtype=dtype)
-        img_mask = np.array([[1, 1, 0], [1, 0, 1]], dtype=np.bool)
-        np.array([[1, 1, 0], [1, 0, 1]], dtype=np.bool)
+        img_mask = np.array([[1, 1, 0], [1, 0, 1]], dtype=bool)
+        np.array([[1, 1, 0], [1, 0, 1]], dtype=bool)
         mask_image_data(img, image_mask=img_mask, keep_nan=keep_nan)
         np.testing.assert_array_equal(np.array([[[mt, mt, 3], [mt, mt, mt]],
                                                 [[mt, mt, 3], [mt, mt, mt]]], dtype=dtype), img)
@@ -358,8 +358,8 @@ class TestMaskImageData:
         # both masks
         img = np.array([[[1, 2, 3], [3, np.nan, np.nan]],
                         [[1, 2, 6], [3, np.nan, np.nan]]], dtype=dtype)
-        img_mask = np.array([[1, 1, 0], [1, 0, 1]], dtype=np.bool)
-        np.array([[1, 1, 0], [1, 0, 1]], dtype=np.bool)
+        img_mask = np.array([[1, 1, 0], [1, 0, 1]], dtype=bool)
+        np.array([[1, 1, 0], [1, 0, 1]], dtype=bool)
         mask_image_data(img, image_mask=img_mask, threshold_mask=(2, 4), keep_nan=keep_nan)
         np.testing.assert_array_equal(np.array([[[mt, mt, 3], [mt, mt, mt]],
                                                 [[mt, mt, mt], [mt, mt, mt]]], dtype=dtype), img)
@@ -389,7 +389,7 @@ class TestMaskImageData:
         out = np.zeros((2, 3), dtype=bool)
         mask_image_data(img, keep_nan=keep_nan, out=out)
         np.testing.assert_array_equal(
-            np.array([[False, False, True], [False, False, False]], dtype=np.bool), out)
+            np.array([[False, False, True], [False, False, False]], dtype=bool), out)
 
         # threshold mask
         img = np.array([[1, 2, np.nan], [3, 4, 5]], dtype=dtype)
@@ -398,23 +398,23 @@ class TestMaskImageData:
         np.testing.assert_array_equal(
             np.array([[mt, 2, mt], [3, mt, mt]], dtype=dtype), img)
         np.testing.assert_array_equal(
-            np.array([[True, False, True], [False, True, True]], dtype=np.bool), out)
+            np.array([[True, False, True], [False, True, True]], dtype=bool), out)
 
         # image mask
         img = np.array([[1, np.nan, np.nan], [3, 4, 5]], dtype=dtype)
-        img_mask = np.array([[1, 1, 0], [1, 0, 1]], dtype=np.bool)
+        img_mask = np.array([[1, 1, 0], [1, 0, 1]], dtype=bool)
         out = np.zeros((2, 3), dtype=bool)
         mask_image_data(img, image_mask=img_mask, keep_nan=keep_nan, out=out)
         np.testing.assert_array_equal(np.array([[mt, mt, mt], [mt, 4, mt]], dtype=dtype), img)
         np.testing.assert_array_equal(
-            np.array([[True, True, True], [True, False, True]], dtype=np.bool), out)
+            np.array([[True, True, True], [True, False, True]], dtype=bool), out)
 
         # both masks
         img = np.array([[1, 2, np.nan], [3, 4, 5]], dtype=dtype)
-        img_mask = np.array([[1, 0, 0], [1, 0, 0]], dtype=np.bool)
+        img_mask = np.array([[1, 0, 0], [1, 0, 0]], dtype=bool)
         out = np.zeros((2, 3), dtype=bool)
         mask_image_data(img, image_mask=img_mask, threshold_mask=(2, 3), keep_nan=keep_nan, out=out)
         np.testing.assert_array_equal(
             np.array([[mt, 2, mt], [mt, mt, mt]], dtype=dtype), img)
         np.testing.assert_array_equal(
-            np.array([[True, False, True], [True, True, True]], dtype=np.bool), out)
+            np.array([[True, False, True], [True, True, True]], dtype=bool), out)

--- a/extra_foam/geometries/__init__.py
+++ b/extra_foam/geometries/__init__.py
@@ -71,7 +71,7 @@ class _1MGeometryPyMixin:
         Match the EXtra-geom signature.
         """
         shape = extra_shape + tuple(self.assembledShape())
-        if dtype == np.bool:
+        if dtype == bool:
             return np.full(shape, 0, dtype=dtype)
         return np.full(shape, np.nan, dtype=dtype)
 
@@ -102,7 +102,7 @@ class _1MGeometryPyMixin:
     def output_array_for_dismantle_fast(self, extra_shape=(), dtype=_IMAGE_DTYPE):
         """Make an array with the shape of data in modules filled with nan."""
         shape = extra_shape + (self.n_modules, *self.module_shape)
-        if dtype == np.bool:
+        if dtype == bool:
             return np.full(shape, 0, dtype=dtype)
         return np.full(shape, np.nan, dtype=dtype)
 
@@ -237,7 +237,7 @@ class _GeometryPyMixin:
         Match the EXtra-geom signature.
         """
         shape = extra_shape + tuple(self.assembledShape())
-        if dtype == np.bool:
+        if dtype == bool:
             return np.full(shape, 0, dtype=dtype)
         return np.full(shape, np.nan, dtype=dtype)
 
@@ -267,7 +267,7 @@ class _GeometryPyMixin:
     def output_array_for_dismantle_fast(self, extra_shape=(), dtype=_IMAGE_DTYPE):
         """Make an array with the shape of data in modules filled with nan."""
         shape = extra_shape + (self.nModules(), *self.module_shape)
-        if dtype == np.bool:
+        if dtype == bool:
             return np.full(shape, 0, dtype=dtype)
         return np.full(shape, np.nan, dtype=dtype)
 

--- a/extra_foam/gui/image_tool/tests/test_image_tool.py
+++ b/extra_foam/gui/image_tool/tests/test_image_tool.py
@@ -293,7 +293,7 @@ class TestImageTool(unittest.TestCase, _TestDataMixin):
         # trigger the lazily evaluated subscriber
         proc.process(data)
 
-        mask_gt = np.zeros(data['assembled']['data'].shape[-2:], dtype=np.bool)
+        mask_gt = np.zeros(data['assembled']['data'].shape[-2:], dtype=bool)
 
         # test default
         np.testing.assert_array_equal(proc._image_mask, mask_gt)
@@ -330,7 +330,7 @@ class TestImageTool(unittest.TestCase, _TestDataMixin):
         # test removing mask
         QTest.mouseClick(widget.remove_btn, Qt.LeftButton)
         proc.process(data)
-        np.testing.assert_array_equal(np.zeros_like(mask_gt, dtype=np.bool), proc._image_mask)
+        np.testing.assert_array_equal(np.zeros_like(mask_gt, dtype=bool), proc._image_mask)
 
         # test set mask
         pub.set(mask_gt)
@@ -338,15 +338,15 @@ class TestImageTool(unittest.TestCase, _TestDataMixin):
         np.testing.assert_array_equal(mask_gt, proc._image_mask)
 
         # test set a mask which has a different shape from the image
-        mask_gt = np.ones((2, 2), dtype=np.bool)
+        mask_gt = np.ones((2, 2), dtype=bool)
         pub.set(mask_gt)
         with self.assertRaises(ImageProcessingError):
             proc.process(data)
         # an empty image mask with a different shape will be automatically reset
-        mask_gt = np.zeros((2, 2), dtype=np.bool)
+        mask_gt = np.zeros((2, 2), dtype=bool)
         pub.set(mask_gt)
         proc.process(data)
-        np.testing.assert_array_equal(np.zeros((10, 10), dtype=np.bool), proc._image_mask)
+        np.testing.assert_array_equal(np.zeros((10, 10), dtype=bool), proc._image_mask)
 
     def testReferenceCtrlWidget(self):
         view = self.image_tool._reference_view

--- a/extra_foam/gui/image_tool/tests/test_views.py
+++ b/extra_foam/gui/image_tool/tests/test_views.py
@@ -114,7 +114,7 @@ class TestViews(_TestDataMixin, unittest.TestCase):
                 QTest.mouseClick(ctrl_widget.detect_btn, Qt.LeftButton)
 
                 # non-empty data
-                image_data = np.random.randn(2, 2).astype(np.float)
+                image_data = np.random.randn(2, 2).astype(float)
                 data.image.transform_type = ImageTransformType.CONCENTRIC_RINGS
                 data.image.masked_mean = image_data
                 data.image.transformed = None

--- a/extra_foam/gui/plot_widgets/image_items.py
+++ b/extra_foam/gui/plot_widgets/image_items.py
@@ -278,7 +278,7 @@ class ImageItem(pg.GraphicsObject):
             # step >= 1
             step = np.ceil((ub - lb) / n_bins)
             # len(bins) >= 2
-            bins = np.arange(lb, ub + 0.01 * step, step, dtype=np.int)
+            bins = np.arange(lb, ub + 0.01 * step, step, dtype=int)
         else:
             # for float data, let numpy select the bins.
             bins = np.linspace(lb, ub, n_bins)

--- a/extra_foam/gui/plot_widgets/image_views.py
+++ b/extra_foam/gui/plot_widgets/image_views.py
@@ -130,7 +130,7 @@ class ImageAnalysis(ImageViewF):
             # We do not use self._mask_in_modules in order to allow users
             # to save mask which has not been applied and send back by the
             # pipeline.
-            modules = geom.output_array_for_dismantle_fast(dtype=np.bool)
+            modules = geom.output_array_for_dismantle_fast(dtype=bool)
             try:
                 geom.dismantle_all_modules(image_mask, out=modules)
             except ValueError as e:

--- a/extra_foam/gui/plot_widgets/tests/test_image_view.py
+++ b/extra_foam/gui/plot_widgets/tests/test_image_view.py
@@ -49,7 +49,7 @@ class TestImageView:
                 getattr(widget, method)()
                 mocked.assert_called_once()
 
-    @pytest.mark.parametrize("dtype", [np.uint8, np.int, np.float32])
+    @pytest.mark.parametrize("dtype", [np.uint8, int, np.float32])
     def testSetImage(self, dtype):
         widget = ImageViewF(has_roi=True)
 
@@ -177,7 +177,7 @@ class TestImageAnalysis(unittest.TestCase):
 
         widget = ImageAnalysis()
         fp = tempfile.NamedTemporaryFile(suffix=".npy")
-        img = np.arange(100, dtype=np.float).reshape(10, 10)
+        img = np.arange(100, dtype=float).reshape(10, 10)
 
         # if image_data is None, it does not raise but only logger.error()
         with self.assertLogs(logger, level="ERROR") as cm:

--- a/extra_foam/gui/plot_widgets/tests/test_plot_items.py
+++ b/extra_foam/gui/plot_widgets/tests/test_plot_items.py
@@ -70,7 +70,7 @@ class TestPlotItems:
         item2.setData(x, y)
         assert QRectF(1., 0., 4., 5.) == item2.boundingRect()
 
-    @pytest.mark.parametrize("dtype", [np.float, np.int64, np.uint16])
+    @pytest.mark.parametrize("dtype", [float, np.int64, np.uint16])
     def testCurvePlotItem(self, dtype):
         x = np.arange(10).astype(dtype)
         y = x * 1.5
@@ -84,7 +84,7 @@ class TestPlotItems:
 
         # x and y are numpy.arrays
         # item.setData(x, y)
-        if dtype == np.float:
+        if dtype == float:
             _display()
 
         # test different lengths
@@ -93,11 +93,11 @@ class TestPlotItems:
 
         # test log mode
         self._widget._plot_area._onLogXChanged(True)
-        if dtype == np.float:
+        if dtype == float:
             _display()
         assert item.boundingRect() == QRectF(0, 0, 1.0, 13.5)
         self._widget._plot_area._onLogYChanged(True)
-        if dtype == np.float:
+        if dtype == float:
             _display()
         assert item.boundingRect().topLeft() == QPointF(0, 0)
         assert item.boundingRect().bottomRight().x() == 1.0
@@ -107,7 +107,7 @@ class TestPlotItems:
         item.setData([], [])
         assert isinstance(item._x, np.ndarray)
         assert isinstance(item._y, np.ndarray)
-        if dtype == np.float:
+        if dtype == float:
             _display()
 
     def testBarGraphItem(self, dtype=np.float32):
@@ -199,7 +199,7 @@ class TestPlotItems:
             self._widget.addLegend()
             _display(interval=0.2)
 
-    def testScatterPlotItem(self, dtype=np.float):
+    def testScatterPlotItem(self, dtype=float):
         x = np.arange(10).astype(dtype)
         y = x * 1.5
 
@@ -212,7 +212,7 @@ class TestPlotItems:
 
         # x and y are numpy.arrays
         item.setData(x, y)
-        if dtype == np.float:
+        if dtype == float:
             _display()
 
         # test different lengths
@@ -221,7 +221,7 @@ class TestPlotItems:
 
         # test log mode
         self._widget._plot_area._onLogXChanged(True)
-        if dtype == np.float:
+        if dtype == float:
             _display()
         assert -0.2 < item.boundingRect().topLeft().x() < 0
         assert -0.22 < item.boundingRect().topLeft().y() < -0.2
@@ -229,7 +229,7 @@ class TestPlotItems:
         assert 13.5 < item.boundingRect().bottomRight().y() < 14.0
 
         self._widget._plot_area._onLogYChanged(True)
-        if dtype == np.float:
+        if dtype == float:
             _display()
         assert -0.1 < item.boundingRect().topLeft().x() < 0
         assert -0.1 < item.boundingRect().topLeft().y() < 0
@@ -240,5 +240,5 @@ class TestPlotItems:
         item.setData([], [])
         assert isinstance(item._x, np.ndarray)
         assert isinstance(item._y, np.ndarray)
-        if dtype == np.float:
+        if dtype == float:
             _display()

--- a/extra_foam/ipc.py
+++ b/extra_foam/ipc.py
@@ -288,7 +288,7 @@ class ImageMaskSub:
         updated = False
 
         if mask is None:
-            mask = np.zeros(shape, dtype=np.bool)
+            mask = np.zeros(shape, dtype=bool)
 
         # process all messages related to mask
         while True:

--- a/extra_foam/pipeline/data_model.py
+++ b/extra_foam/pipeline/data_model.py
@@ -549,7 +549,7 @@ class ImageData:
 
         instance.masked_mean = instance.mean.copy()
         if image_mask is None:
-            image_mask = np.zeros(arr.shape[-2:], dtype=np.bool)
+            image_mask = np.zeros(arr.shape[-2:], dtype=bool)
         instance.image_mask = image_mask
 
         instance.mask = np.zeros_like(image_mask)

--- a/extra_foam/pipeline/processors/image_processor.py
+++ b/extra_foam/pipeline/processors/image_processor.py
@@ -64,7 +64,7 @@ class ImageProcessor(_BaseProcessor):
         _image_mask (numpy.ndarray): image mask. For pulse-resolved detectors,
             this image mask is shared by all the pulses in a train. However,
             their overall mask could still be different after applying the
-            threshold mask. Shape = (y, x), dtype = np.bool
+            threshold mask. Shape = (y, x), dtype = bool
         _threshold_mask (tuple):  (lower, upper) of the threshold.
             It should be noted that a pixel with value outside of the boundary
             will be masked as Nan/0, depending on the masking policy.
@@ -279,7 +279,7 @@ class ImageProcessor(_BaseProcessor):
 
             if self._image_mask_in_modules is None:
                 self._image_mask_in_modules = geom.output_array_for_dismantle_fast(
-                    dtype=np.bool)
+                    dtype=bool)
 
             try:
                 geom.dismantle_all_modules(
@@ -292,12 +292,12 @@ class ImageProcessor(_BaseProcessor):
         if image_mask.shape != image_shape:
             if np.sum(image_mask) == 0:
                 # reset the empty image mask automatically
-                image_mask = np.zeros(image_shape, dtype=np.bool)
+                image_mask = np.zeros(image_shape, dtype=bool)
             else:
                 if self._require_geom:
                     # reassemble a mask
                     geom = self._assembler.geometry
-                    image_mask = geom.output_array_for_position_fast(dtype=np.bool)
+                    image_mask = geom.output_array_for_position_fast(dtype=bool)
                     geom.position_all_modules(
                         self._image_mask_in_modules, image_mask)
                 else:

--- a/extra_foam/pipeline/processors/tests/test_azimuthal_integration.py
+++ b/extra_foam/pipeline/processors/tests/test_azimuthal_integration.py
@@ -37,7 +37,7 @@ class TestAzimuthalIntegProcessorTrain(_TestDataMixin):
         proc._integ_method = method
 
         shape = (4, 128, 64)
-        image_mask = np.zeros(shape[-2:], dtype=np.bool)
+        image_mask = np.zeros(shape[-2:], dtype=bool)
         image_mask[:, ::2] = True
         data, processed = self.data_with_assembled(1001, shape,
                                                    image_mask=image_mask,
@@ -73,7 +73,7 @@ class TestAzimuthalIntegProcessorTrain(_TestDataMixin):
         proc = self._proc
 
         shape = (4, 128, 64)
-        image_mask = np.zeros(shape[-2:], dtype=np.bool)
+        image_mask = np.zeros(shape[-2:], dtype=bool)
         image_mask[::2, ::2] = True
         threshold_mask = (0, 0.5)
         data, processed = self.data_with_assembled(1001, shape,

--- a/extra_foam/pipeline/processors/tests/test_image_processor.py
+++ b/extra_foam/pipeline/processors/tests/test_image_processor.py
@@ -185,7 +185,7 @@ class _ImageProcessorTestBase(_TestDataMixin, unittest.TestCase):
             info.reset_mock()
 
         with patch.object(proc._ref_sub, "update",
-                          return_value=(True, np.zeros((2, 2), dtype=np.bool))):
+                          return_value=(True, np.zeros((2, 2), dtype=bool))):
             proc.process(data)
             self.assertEqual(_IMAGE_DTYPE, proc._reference.dtype)
             np.testing.assert_array_equal(np.zeros((2, 2)), proc._reference)
@@ -221,7 +221,7 @@ class TestImageProcessorTr(_ImageProcessorTestBase):
         self._proc._cal_sub.update = MagicMock(
             side_effect=lambda: (False, None, False, None))   # no redis server
         self._proc._mask_sub.update = MagicMock(
-            side_effect=lambda x, y: (False, np.zeros(y, dtype=np.bool) if x is None else x))
+            side_effect=lambda x, y: (False, np.zeros(y, dtype=bool) if x is None else x))
 
         self._proc._threshold_mask = (-100, 100)
 
@@ -272,7 +272,7 @@ class TestImageProcessorTr(_ImageProcessorTestBase):
 
     def testImageShapeChangeOnTheFly(self):
         proc = self._proc
-        proc._image_mask = np.ones((2, 2), dtype=np.bool)
+        proc._image_mask = np.ones((2, 2), dtype=bool)
 
         data, _ = self.data_with_assembled(1, (2, 2))
         proc.process(data)
@@ -283,7 +283,7 @@ class TestImageProcessorTr(_ImageProcessorTestBase):
             proc.process(data)
 
         # image mask remains the same, one needs to clear it by hand
-        np.testing.assert_array_equal(np.ones((2, 2), dtype=np.bool), proc._image_mask)
+        np.testing.assert_array_equal(np.ones((2, 2), dtype=bool), proc._image_mask)
         proc._image_mask = None
 
 
@@ -304,7 +304,7 @@ class TestImageProcessorPr(_ImageProcessorTestBase):
         self._proc._cal_sub.update = MagicMock(
             side_effect=lambda: (False, None, False, None))   # no redis server
         self._proc._mask_sub.update = MagicMock(
-            side_effect=lambda x, y: (False, np.zeros(y, dtype=np.bool) if x is None else x))
+            side_effect=lambda x, y: (False, np.zeros(y, dtype=bool) if x is None else x))
 
         del self._proc._dark
         del self._proc._raw
@@ -554,7 +554,7 @@ class TestImageProcessorPr(_ImageProcessorTestBase):
 
     def testImageShapeChangeOnTheFly(self):
         proc = self._proc
-        proc._image_mask = np.ones((2, 2), dtype=np.bool)
+        proc._image_mask = np.ones((2, 2), dtype=bool)
 
         data, _ = self.data_with_assembled(1, (4, 2, 2))
         proc.process(data)
@@ -565,7 +565,7 @@ class TestImageProcessorPr(_ImageProcessorTestBase):
             proc.process(data)
 
         # image mask remains the same, one needs to clear it by hand
-        np.testing.assert_array_equal(np.ones((2, 2), dtype=np.bool), proc._image_mask)
+        np.testing.assert_array_equal(np.ones((2, 2), dtype=bool), proc._image_mask)
         proc._image_mask = None
 
         # Number of pulses per train changes, but no exception will be raised

--- a/extra_foam/pipeline/processors/tests/test_pump_probe.py
+++ b/extra_foam/pipeline/processors/tests/test_pump_probe.py
@@ -51,7 +51,7 @@ class TestPumpProbeProcessorTr(_PumpProbeTestMixin, _TestDataMixin, unittest.Tes
 
     def _gen_data(self, tid, with_xgm=True, with_digitizer=True):
         shape = (3, 2)
-        image_mask = np.zeros(shape, dtype=np.bool)
+        image_mask = np.zeros(shape, dtype=bool)
         image_mask[1, 1] = True
         return self.data_with_assembled(tid, shape,
                                         image_mask=image_mask,
@@ -206,7 +206,7 @@ class TestPumpProbeProcessorPr(_PumpProbeTestMixin, _TestDataMixin, unittest.Tes
 
     def _gen_data(self, tid, with_xgm=True, with_digitizer=True):
         shape = (3, 2)
-        image_mask = np.zeros(shape, dtype=np.bool)
+        image_mask = np.zeros(shape, dtype=bool)
         image_mask[1, 1] = True
         data, processed = self.data_with_assembled(
             tid, (4, 3, 2),

--- a/extra_foam/pipeline/tests/test_data_model.py
+++ b/extra_foam/pipeline/tests/test_data_model.py
@@ -257,7 +257,7 @@ class TestImageData(unittest.TestCase):
 
         imgs = np.ones((3, 2, 3))
         imgs[:, 0, :] = 2
-        image_mask = np.zeros((2, 3), dtype=np.bool)
+        image_mask = np.zeros((2, 3), dtype=bool)
         image_mask[::2, ::2] = True
         image_data = ImageData.from_array(imgs,
                                           image_mask=image_mask,

--- a/extra_foam/serialization.py
+++ b/extra_foam/serialization.py
@@ -33,8 +33,8 @@ def serialize_image(img, is_mask=False):
         raise ValueError(f"The shape of image must be (y, x)!")
 
     if is_mask:
-        if img.dtype != np.bool:
-            img = img.astype(np.bool)
+        if img.dtype != bool:
+            img = img.astype(bool)
         return struct.pack('>II', *img.shape) + np.packbits(img).tobytes()
 
     return struct.pack('>II', *img.shape) + img.tobytes()
@@ -55,7 +55,7 @@ def deserialize_image(data, dtype=_DEFAULT_DTYPE, is_mask=False):
 
     if is_mask:
         packed_bits = np.frombuffer(data, dtype=np.uint8, offset=offset)
-        img = np.unpackbits(packed_bits)[:w*h].astype(np.bool, copy=False)
+        img = np.unpackbits(packed_bits)[:w*h].astype(bool, copy=False)
         img.shape = w, h
         return img
 

--- a/extra_foam/tests/test_serialization.py
+++ b/extra_foam/tests/test_serialization.py
@@ -40,14 +40,14 @@ class TestSerialization(unittest.TestCase):
         self.assertEqual(np.float32, img.dtype)
 
         # test serializing and deserializing a mask
-        orig_mask = np.array([[1, 1, 0], [0, 1, 1]], dtype=np.bool)
+        orig_mask = np.array([[1, 1, 0], [0, 1, 1]], dtype=bool)
 
         mask_bytes = serialize_image(orig_mask, is_mask=True)
         mask = deserialize_image(mask_bytes, is_mask=True)
 
         np.testing.assert_array_equal(orig_mask, mask)
         self.assertEqual(orig_mask.shape, mask.shape)
-        self.assertEqual(np.bool, mask.dtype)
+        self.assertEqual(bool, mask.dtype)
 
         # test casting array into a mask
         orig_mask = np.array([[1., 1., 0], [0, -1., 1.]], dtype=np.float32)
@@ -55,9 +55,9 @@ class TestSerialization(unittest.TestCase):
         mask_bytes = serialize_image(orig_mask, is_mask=True)
         mask = deserialize_image(mask_bytes, is_mask=True)
 
-        np.testing.assert_array_equal(orig_mask.astype(np.bool), mask)
+        np.testing.assert_array_equal(orig_mask.astype(bool), mask)
         self.assertEqual(orig_mask.shape, mask.shape)
-        self.assertEqual(np.bool, mask.dtype)
+        self.assertEqual(bool, mask.dtype)
 
         # test serializing and deserializing a group of images
         orig_imgs = np.array([[[1, 2], [3, 4]],

--- a/extra_foam/utils.py
+++ b/extra_foam/utils.py
@@ -42,6 +42,36 @@ def profiler(info, *, process_time=False):
     return wrap
 
 
+
+class BlockTimer:
+    """A context manager for measuring the execution time of a code block
+
+    For example::
+
+        >>> with BlockTimer("foo"):
+        ...     time.sleep(1)
+        ...
+        Execution of foo: 1.001s
+    """
+    def __init__(self, label="block", enabled=True):
+        """Create the timer object
+
+        :param str label: A name to identify the block being timed.
+        :param bool enabled: Whether or not to enable this timer.
+        """
+        self._label = label
+        self._enabled = enabled
+
+    def __enter__(self):
+        self.start = time.perf_counter()
+        return self
+
+    def __exit__(self, *_):
+        duration = time.perf_counter() - self.start
+        if self._enabled:
+            logger.info(f"Execution of {self._label}: {duration:.4f}s")
+
+
 _NOT_FOUND = object()
 
 


### PR DESCRIPTION
Two changes:
- Fix all deprecation warnings from Numpy 1.20
- Add a context manager to time blocks of code. I found this very useful to quickly time specific blocks.