### PR TITLE
Add extra FOMs for azimuthal integration

### DIFF
--- a/docs/analysis_type.rst
+++ b/docs/analysis_type.rst
@@ -3,8 +3,8 @@
 Analysis type
 =============
 
-Each analysis will generate a FOM (figure-of-merit) and possibly also a VFOM (vector figure-of-merit),
-which are typically used in :ref:`statistics analysis`.
+Each analysis will generate at least one FOM (figure-of-merit) and possibly also
+a VFOM (vector figure-of-merit), which are typically used in :ref:`statistics analysis`.
 
 **FOM**
 
@@ -17,7 +17,7 @@ For instance:
 
 **VFOM**
 
-An array of scalars  which is used to characterize the performance of an analysis in a train/pulse.
+An array of scalars which is used to characterize the performance of an analysis in a train/pulse.
 For instance:
 
 - Scattering curve from azimuthal integration;
@@ -49,4 +49,5 @@ For instance:
    * - *azimuthal integ*
      - 1D Azimuthal integration of average (pulse) image(s) in a train.
      - Azimuthal integration scattering curve.
-     - Sum of the scattering curve.
+     - Sum of the scattering curve, the value of the largest peak in the curve,
+       :math:`q` of the largest peak, and the :math:`q` of the center of mass.

--- a/extra_foam/config.py
+++ b/extra_foam/config.py
@@ -10,7 +10,7 @@ All rights reserved.
 from enum import IntEnum
 import os.path as osp
 import shutil
-from collections import abc, namedtuple
+from collections import abc, namedtuple, OrderedDict
 
 import yaml
 from yaml.scanner import ScannerError
@@ -77,6 +77,9 @@ class AnalysisType(IntEnum):
     ROI_NORM = 12
     ROI_PROJ = 21
     AZIMUTHAL_INTEG = 41
+    AZIMUTHAL_INTEG_PEAK = 42
+    AZIMUTHAL_INTEG_PEAK_Q = 43
+    AZIMUTHAL_INTEG_COM = 44
     PULSE = 2700
     PUMP_PROBE_PULSE = 2701
     ROI_FOM_PULSE = 2711
@@ -105,6 +108,26 @@ class PipelineSlowPolicy(IntEnum):
 class CalibrationOffsetPolicy(IntEnum):
     UNDEFINED = 0
     INTRA_DARK = 1
+
+
+_user_analysis_types = OrderedDict({
+    "": AnalysisType.UNDEFINED,
+    "pump-probe": AnalysisType.PUMP_PROBE,
+    "ROI FOM": AnalysisType.ROI_FOM,
+    "ROI proj": AnalysisType.ROI_PROJ,
+    "azimuthal integ (sum)": AnalysisType.AZIMUTHAL_INTEG,
+    "azimuthal integ (peak)": AnalysisType.AZIMUTHAL_INTEG_PEAK,
+    "azimuthal integ (peak q)": AnalysisType.AZIMUTHAL_INTEG_PEAK_Q,
+    "azimuthal integ (CoM)": AnalysisType.AZIMUTHAL_INTEG_COM
+})
+
+
+def get_analysis_types(without=None):
+    if without is not None:
+        return { k: v for k, v in _user_analysis_types.items()
+                 if v != without }
+    else:
+        return _user_analysis_types
 
 
 def list_azimuthal_integ_methods(detector):

--- a/extra_foam/gui/ctrl_widgets/bin_ctrl_widget.py
+++ b/extra_foam/gui/ctrl_widgets/bin_ctrl_widget.py
@@ -45,7 +45,7 @@ class BinCtrlWidget(_AbstractCtrlWidget):
 
     _bin_modes = OrderedDict({
         "average": BinMode. AVERAGE,
-        "accumulcate": BinMode.ACCUMULATE,
+        "accumulate": BinMode.ACCUMULATE,
     })
     _bin_modes_inv = invert_dict(_bin_modes)
 

--- a/extra_foam/gui/ctrl_widgets/bin_ctrl_widget.py
+++ b/extra_foam/gui/ctrl_widgets/bin_ctrl_widget.py
@@ -20,7 +20,7 @@ from PyQt5.QtWidgets import (
 from .base_ctrl_widgets import _AbstractCtrlWidget
 from .smart_widgets import SmartBoundaryLineEdit, SmartLineEdit
 from ..gui_helpers import invert_dict
-from ...config import AnalysisType, BinMode, config
+from ...config import AnalysisType, BinMode, config, get_analysis_types
 from ...database import Metadata as mt
 from ...database import SourceCatalog
 
@@ -33,14 +33,7 @@ _MAX_N_BINS = 999
 
 class BinCtrlWidget(_AbstractCtrlWidget):
     """Widget for setting up binning analysis parameters."""
-
-    _analysis_types = OrderedDict({
-        "": AnalysisType.UNDEFINED,
-        "pump-probe": AnalysisType.PUMP_PROBE,
-        "ROI FOM": AnalysisType.ROI_FOM,
-        "ROI proj": AnalysisType.ROI_PROJ,
-        "azimuthal integ": AnalysisType.AZIMUTHAL_INTEG,
-    })
+    _analysis_types = get_analysis_types()
     _analysis_types_inv = invert_dict(_analysis_types)
 
     _bin_modes = OrderedDict({

--- a/extra_foam/gui/ctrl_widgets/correlation_ctrl_widget.py
+++ b/extra_foam/gui/ctrl_widgets/correlation_ctrl_widget.py
@@ -7,7 +7,6 @@ Author: Jun Zhu <jun.zhu@xfel.eu>, Ebad Kamil <ebad.kamil@xfel.eu>
 Copyright (C) European X-Ray Free-Electron Laser Facility GmbH.
 All rights reserved.
 """
-from collections import OrderedDict
 import functools
 
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, Qt
@@ -21,7 +20,7 @@ from .curve_fitting_ctrl_widget import _BaseFittingCtrlWidget
 from .base_ctrl_widgets import _AbstractCtrlWidget
 from .smart_widgets import SmartLineEdit
 from ..gui_helpers import invert_dict
-from ...config import AnalysisType, config
+from ...config import AnalysisType, config, get_analysis_types
 from ...database import Metadata as mt
 from ...database import SourceCatalog
 
@@ -81,14 +80,7 @@ class _FittingCtrlWidget(_BaseFittingCtrlWidget):
 
 class CorrelationCtrlWidget(_AbstractCtrlWidget):
     """Widget for setting up correlation analysis parameters."""
-
-    _analysis_types = OrderedDict({
-        "": AnalysisType.UNDEFINED,
-        "pump-probe": AnalysisType.PUMP_PROBE,
-        "ROI FOM": AnalysisType.ROI_FOM,
-        "ROI proj": AnalysisType.ROI_PROJ,
-        "azimuthal integ": AnalysisType.AZIMUTHAL_INTEG,
-    })
+    _analysis_types = get_analysis_types()
     _analysis_types_inv = invert_dict(_analysis_types)
 
     _user_defined_key = config["SOURCE_USER_DEFINED_CATEGORY"]

--- a/extra_foam/gui/ctrl_widgets/pump_probe_ctrl_widget.py
+++ b/extra_foam/gui/ctrl_widgets/pump_probe_ctrl_widget.py
@@ -18,7 +18,7 @@ from PyQt5.QtWidgets import (
 from .base_ctrl_widgets import _AbstractCtrlWidget
 from .smart_widgets import SmartSliceLineEdit
 from ..gui_helpers import invert_dict
-from ...config import PumpProbeMode, AnalysisType
+from ...config import PumpProbeMode, AnalysisType, get_analysis_types
 from ...database import Metadata as mt
 
 
@@ -33,12 +33,7 @@ class PumpProbeCtrlWidget(_AbstractCtrlWidget):
         "same train": PumpProbeMode.SAME_TRAIN,
     })
 
-    _analysis_types = OrderedDict({
-        "": AnalysisType.UNDEFINED,
-        "ROI FOM": AnalysisType.ROI_FOM,
-        "ROI proj": AnalysisType.ROI_PROJ,
-        "azimuthal integ": AnalysisType.AZIMUTHAL_INTEG,
-    })
+    _analysis_types = get_analysis_types(without=AnalysisType.PUMP_PROBE)
     _analysis_types_inv = invert_dict(_analysis_types)
 
     def __init__(self, *args, **kwargs):

--- a/extra_foam/gui/image_tool/azimuthal_integ_1d_view.py
+++ b/extra_foam/gui/image_tool/azimuthal_integ_1d_view.py
@@ -61,6 +61,11 @@ class AzimuthalInteg1dPlot(PlotWidgetF):
 
     def setFitted(self, x, y):
         self._fitted.setData(x, y)
+        com_x, com_y = ai.center_of_mass
+        if com_x == np.nan or com_y == np.nan:
+            self._center_of_mass.setData([], [])
+        else:
+            self._center_of_mass.setData([com_x], [com_y])
 
 
 @create_imagetool_view(AzimuthalIntegCtrlWidget)

--- a/extra_foam/gui/image_tool/azimuthal_integ_1d_view.py
+++ b/extra_foam/gui/image_tool/azimuthal_integ_1d_view.py
@@ -7,6 +7,8 @@ Author: Jun Zhu <jun.zhu@xfel.eu>
 Copyright (C) European X-Ray Free-Electron Laser Facility GmbH.
 All rights reserved.
 """
+import numpy as np
+
 from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtWidgets import QVBoxLayout, QSplitter, QTabWidget
 
@@ -37,6 +39,7 @@ class AzimuthalInteg1dPlot(PlotWidgetF):
             pen=FColor.mkPen("g"), brush=FColor.mkBrush(None), symbol="o",
             size=18)
         self._fitted = self.plotCurve(pen=FColor.mkPen("g"))
+        self._center_of_mass = self.plotScatter(pen=FColor.mkPen("r"), symbol="o", size=18)
 
     def updateF(self, data):
         """Override."""
@@ -158,7 +161,9 @@ class AzimuthalInteg1dView(_AbstractImageToolView):
     def onActivated(self):
         """Override."""
         self._mediator.registerAnalysis(AnalysisType.AZIMUTHAL_INTEG)
+        self._mediator.registerAnalysis(AnalysisType.AZIMUTHAL_INTEG_COM)
 
     def onDeactivated(self):
         """Override."""
         self._mediator.unregisterAnalysis(AnalysisType.AZIMUTHAL_INTEG)
+        self._mediator.unregisterAnalysis(AnalysisType.AZIMUTHAL_INTEG_COM)

--- a/extra_foam/gui/image_tool/tests/test_views.py
+++ b/extra_foam/gui/image_tool/tests/test_views.py
@@ -80,6 +80,7 @@ class TestViews(_TestDataMixin, unittest.TestCase):
         data = self.processed_data(1001, (2, 2))
         data.ai.x = np.arange(10)
         data.ai.y = np.arange(10)
+        data.ai.center_of_mass = (1, 1)
         view.updateF(data, True)
         data.ai.peaks = np.arange(10)
         with patch.object(view._azimuthal_integ_1d_curve, "setAnnotationList") as mocked:

--- a/extra_foam/gui/windows/tests/test_plot_windows.py
+++ b/extra_foam/gui/windows/tests/test_plot_windows.py
@@ -11,10 +11,11 @@ from PyQt5.QtCore import QPoint, Qt
 from PyQt5.QtTest import QTest, QSignalSpy
 
 from extra_foam.algorithms import FittingType
-from extra_foam.config import AnalysisType, BinMode, config, PumpProbeMode
+from extra_foam.config import AnalysisType, BinMode, config, PumpProbeMode, get_analysis_types
 from extra_foam.database import Metadata as mt
 from extra_foam.logger import logger
 from extra_foam.gui import mkQApp
+from extra_foam.gui.gui_helpers import invert_dict
 from extra_foam.gui.windows import (
     BinningWindow, CorrelationWindow, HistogramWindow,
     PulseOfInterestWindow, PumpProbeWindow,
@@ -347,6 +348,7 @@ class TestPlotWindows(unittest.TestCase):
         self.assertTrue(pp_proc._reset)
 
         # test loading meta data
+        analysis_names = invert_dict(get_analysis_types())
         mediator = widget._mediator
         mediator.onPpAnalysisTypeChange(AnalysisType.AZIMUTHAL_INTEG)
         mediator.onPpModeChange(PumpProbeMode.ODD_TRAIN_ON)
@@ -354,7 +356,7 @@ class TestPlotWindows(unittest.TestCase):
         mediator.onPpOffPulseSlicerChange([1, None, 2])
         mediator.onPpAbsDifferenceChange(True)
         widget.loadMetaData()
-        self.assertEqual("azimuthal integ", widget._analysis_type_cb.currentText())
+        self.assertEqual(analysis_names[AnalysisType.AZIMUTHAL_INTEG], widget._analysis_type_cb.currentText())
         self.assertEqual("odd/even train", widget._mode_cb.currentText())
         self.assertEqual(True, widget._abs_difference_cb.isChecked())
         self.assertEqual("0::2", widget._on_pulse_le.text())
@@ -416,7 +418,7 @@ class TestPlotWindows(unittest.TestCase):
 
         widget = win._ctrl_widget
         analysis_ctrl_widget = self.gui.analysis_ctrl_widget
-        analysis_types = {value: key for key, value in widget._analysis_types.items()}
+        analysis_names = invert_dict(get_analysis_types())
 
         for i in range(_N_PARAMS):
             # test category list
@@ -447,7 +449,7 @@ class TestPlotWindows(unittest.TestCase):
                 self.assertFalse(proc._auto_reset_ma)
 
         # set new values
-        widget._analysis_type_cb.setCurrentText(analysis_types[AnalysisType.ROI_PROJ])
+        widget._analysis_type_cb.setCurrentText(analysis_names[AnalysisType.ROI_PROJ])
         widget._auto_reset_ma_cb.setChecked(False)
         for i, proc in enumerate(processors):
             proc._reset = False

--- a/extra_foam/pipeline/data_model.py
+++ b/extra_foam/pipeline/data_model.py
@@ -188,12 +188,15 @@ class DataItem:
 
 class AzimuthalIntegrationData(DataItem):
     """Azimuthal integration data item."""
-    __slots__ = ['x', 'y', 'fom', 'q_map', 'peaks']
+    __slots__ = ['q_map', 'peaks', 'max_peak', 'max_peak_q', 'center_of_mass']
 
     def __init__(self):
         super().__init__()
         self.q_map = None
         self.peaks = None
+        self.max_peak = None
+        self.max_peak_q = None
+        self.center_of_mass = None
 
 
 class _RoiGeomBase(ABC):
@@ -358,7 +361,7 @@ class RoiDataTrain(DataItem):
         self.hist = _HistogramDataItem()
 
 
-class PumpProbeData(DataItem):
+class PumpProbeData(AzimuthalIntegrationData):
     """Pump-probe data."""
 
     class OnOff:

--- a/extra_foam/pipeline/processors/tests/test_azimuthal_integration.py
+++ b/extra_foam/pipeline/processors/tests/test_azimuthal_integration.py
@@ -1,14 +1,30 @@
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
 import numpy as np
 
 from extra_foam.pipeline.tests import _TestDataMixin
+from extra_foam.pipeline.data_model import AzimuthalIntegrationData, PumpProbeData
 from extra_foam.pipeline.processors import (
     AzimuthalIntegProcessorTrain, AzimuthalIntegProcessorPulse
 )
+from extra_foam.pipeline.exceptions import ProcessingError
 from extra_foam.algorithms import mask_image_data
 from extra_foam.config import AnalysisType, list_azimuthal_integ_methods
+
+
+_analysis_types = [AnalysisType.AZIMUTHAL_INTEG,
+                   AnalysisType.AZIMUTHAL_INTEG_PEAK,
+                   AnalysisType.AZIMUTHAL_INTEG_PEAK_Q,
+                   AnalysisType.AZIMUTHAL_INTEG_COM]
+
+
+@contextmanager
+def patch_proc(proc, analysis_type):
+    with patch.object(proc._meta, 'has_analysis', side_effect=lambda x: analysis_type == x) as one, \
+         patch.object(proc._meta, 'has_any_analysis', side_effect=lambda x: analysis_type in x) as two:
+        yield (one, two)
 
 
 class TestAzimuthalIntegProcessorTrain(_TestDataMixin):
@@ -31,27 +47,48 @@ class TestAzimuthalIntegProcessorTrain(_TestDataMixin):
 
         self._proc = proc
 
+    def create_test_data(self, row_mask=np.s_[:]):
+        shape = (4, 128, 64)
+        image_mask = np.zeros(shape[-2:], dtype=bool)
+        image_mask[row_mask, ::2] = True
+        threshold_mask = (0, 0.5)
+        data, processed = self.data_with_assembled(1001, shape,
+                                                   image_mask=image_mask,
+                                                   threshold_mask=threshold_mask)
+
+        return data, processed, image_mask, threshold_mask
+
+    def extract_fom(self, ai, analysis_type):
+        if analysis_type == AnalysisType.AZIMUTHAL_INTEG:
+            return ai.fom
+        elif analysis_type == AnalysisType.AZIMUTHAL_INTEG_PEAK:
+            return ai.max_peak
+        elif analysis_type == AnalysisType.AZIMUTHAL_INTEG_PEAK_Q:
+            return ai.max_peak_q
+        elif analysis_type == AnalysisType.AZIMUTHAL_INTEG_COM:
+            return ai.center_of_mass
+        else:
+            raise NotImplementedError
+
+    @pytest.mark.parametrize("analysis_type", _analysis_types)
     @pytest.mark.parametrize("method", list_azimuthal_integ_methods("LPD"))
-    def testAzimuthalIntegration(self, method):
+    def testAzimuthalIntegration(self, method, analysis_type):
         proc = self._proc
         proc._integ_method = method
 
-        shape = (4, 128, 64)
-        image_mask = np.zeros(shape[-2:], dtype=bool)
-        image_mask[:, ::2] = True
-        data, processed = self.data_with_assembled(1001, shape,
-                                                   image_mask=image_mask,
-                                                   threshold_mask=(0, 0.5))
-        with patch.object(proc._meta, 'has_analysis',
-                          side_effect=lambda x: True if x == AnalysisType.AZIMUTHAL_INTEG else False):
+        data, processed, _, _ = self.create_test_data()
+
+        with patch_proc(proc, analysis_type):
             proc.process(data)
 
             ai = processed.ai
+            fom = self.extract_fom(ai, analysis_type)
+
             assert len(ai.x) == proc._integ_points
             assert all([not np.isnan(v) for v in ai.y])
             assert len(ai.y) == proc._integ_points
             assert all([not np.isnan(v) for v in ai.y])
-            assert ai.fom is not None and ai.fom != 0
+            assert fom is not None and fom != 0
             # assert shape[-2:] == ai.q_map.shape
             assert ai.peaks is None
 
@@ -69,16 +106,11 @@ class TestAzimuthalIntegProcessorTrain(_TestDataMixin):
                 proc.process(data)
                 assert ai.peaks is None
 
-    def testAzimuthalIntegrationPp(self):
+    @pytest.mark.parametrize("analysis_type", _analysis_types)
+    def testAzimuthalIntegrationPp(self, analysis_type):
         proc = self._proc
 
-        shape = (4, 128, 64)
-        image_mask = np.zeros(shape[-2:], dtype=bool)
-        image_mask[::2, ::2] = True
-        threshold_mask = (0, 0.5)
-        data, processed = self.data_with_assembled(1001, shape,
-                                                   image_mask=image_mask,
-                                                   threshold_mask=threshold_mask)
+        data, processed, image_mask, threshold_mask = self.create_test_data(row_mask=np.s_[::2])
 
         image_on = np.nanmean(data['assembled']['sliced'][::2, ...], axis=0)
         mask_on = np.zeros_like(image_mask)
@@ -95,15 +127,16 @@ class TestAzimuthalIntegProcessorTrain(_TestDataMixin):
                         out=mask_off)
 
         pp = processed.pp
-        pp.analysis_type = AnalysisType.AZIMUTHAL_INTEG
+        pp.analysis_type = analysis_type
         pp.image_on = image_on
         pp.image_off = image_off
         pp.on.mask = mask_on
         pp.off.mask = mask_off
 
-        with patch.object(proc._meta, 'has_analysis',
-                          side_effect=lambda x: True if x == AnalysisType.AZIMUTHAL_INTEG else False):
+        with patch_proc(proc, analysis_type):
             proc.process(data)
+
+            fom = self.extract_fom(pp, analysis_type)
 
             assert len(pp.y_on) == proc._integ_points
             assert all([not np.isnan(v) for v in pp.y_on])
@@ -111,4 +144,56 @@ class TestAzimuthalIntegProcessorTrain(_TestDataMixin):
             assert all([not np.isnan(v) for v in pp.y_off])
             assert len(pp.x) == proc._integ_points
             assert len(pp.y) == proc._integ_points
-            assert pp.fom is not None and pp.fom != 0
+            assert fom is not None and fom != 0
+
+    def testComputeFom(self):
+        proc = self._proc
+
+        ai = AzimuthalIntegrationData()
+        ai.x = np.arange(0, 10)
+        ai.y = np.arange(-5, 5)
+
+        with patch_proc(proc, AnalysisType.AZIMUTHAL_INTEG) as (has_analysis, _):
+            proc._process_fom(ai)
+
+            # Sanity test
+            has_analysis.assert_called()
+            assert np.sum(np.abs(ai.y)) == ai.fom
+
+        with patch_proc(proc, AnalysisType.AZIMUTHAL_INTEG_COM):
+            proc._process_fom(ai)
+
+            # Negative CoMs should be discarded
+            assert ai.center_of_mass == (np.nan, np.nan)
+
+        # Attempting to find peak FoMs should fail if peak finding is disabled
+        proc._find_peaks = False
+        with patch_proc(proc, AnalysisType.AZIMUTHAL_INTEG_PEAK), pytest.raises(ProcessingError):
+            proc._process_fom(ai)
+        with patch_proc(proc, AnalysisType.AZIMUTHAL_INTEG_PEAK_Q), pytest.raises(ProcessingError):
+            proc._process_fom(ai)
+
+        proc._find_peaks = True
+
+        # If there are no peaks, we should get NaNs
+        with patch_proc(proc, AnalysisType.AZIMUTHAL_INTEG_PEAK):
+            proc._process_fom(ai)
+            assert np.isnan(ai.max_peak)
+        with patch_proc(proc, AnalysisType.AZIMUTHAL_INTEG_PEAK_Q):
+            proc._process_fom(ai)
+            assert np.isnan(ai.max_peak_q)
+
+        # Check behaviour when pump-probe analysis is requested
+        ai = PumpProbeData()
+        ai.x = np.arange(0, 10)
+        ai.y = np.arange(-5, 5)
+
+        # Sanity test
+        ai.analysis_type = AnalysisType.AZIMUTHAL_INTEG
+        proc._process_fom(ai)
+        assert np.sum(np.abs(ai.y)) == ai.fom
+
+        # abs_difference should be respected
+        ai.abs_difference = False
+        proc._process_fom(ai)
+        assert np.sum(ai.y) == ai.fom

--- a/extra_foam/pipeline/processors/tests/test_correlation.py
+++ b/extra_foam/pipeline/processors/tests/test_correlation.py
@@ -7,16 +7,12 @@ from extra_foam.pipeline.processors.correlation import (
     CorrelationProcessor, SimplePairSequence, OneWayAccuPairSequence
 )
 
-from extra_foam.config import AnalysisType
+from extra_foam.config import AnalysisType, get_analysis_types
 
 from extra_foam.pipeline.tests import _TestDataMixin
 
 
-_analysis_types = [AnalysisType.PUMP_PROBE,
-                   AnalysisType.ROI_FOM,
-                   AnalysisType.ROI_PROJ,
-                   AnalysisType.AZIMUTHAL_INTEG]
-
+_analysis_types = list(get_analysis_types(without=AnalysisType.UNDEFINED).values())
 
 class TestCorrelationProcessor(_TestDataMixin):
 
@@ -29,6 +25,12 @@ class TestCorrelationProcessor(_TestDataMixin):
             processed.roi.proj.fom = fom
         elif analysis_type == AnalysisType.AZIMUTHAL_INTEG:
             processed.ai.fom = fom
+        elif analysis_type == AnalysisType.AZIMUTHAL_INTEG_PEAK:
+            processed.ai.max_peak = fom
+        elif analysis_type == AnalysisType.AZIMUTHAL_INTEG_PEAK_Q:
+            processed.ai.max_peak_q = fom
+        elif analysis_type == AnalysisType.AZIMUTHAL_INTEG_COM:
+            processed.ai.center_of_mass = (fom, fom)
         else:
             raise NotImplementedError
 


### PR DESCRIPTION
This was part of MID's moonshot project, it implements some more azimuthal integration (AI) FOMs:
- Peak _I(q)_
- _q_ of the peak
- The _q_ of the center of mass of the _I(q)_

Unfortunately this breaks the abstraction of 'only one FOM per analysis type', which leads to some rather dubious code in e.g. `base_processor.py`. We could just re-use the `.fom` slot of `data_model.AzimuthalIntegrationData` for whichever FOM is currently selected, but that means that it wouldn't be possible to use multiple AI FOMs at once. I think that would be quite confusing for users; plus, using multiple AI FOMs simultaneously could be useful.

![image](https://user-images.githubusercontent.com/5361518/121711900-6240e200-cadb-11eb-97e8-a2dfd8aff828.png)
