### PR TITLE
Update pyzmq to fix a memory leak

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -299,7 +299,7 @@ setup(
         'scipy>=1.2.1',
         'msgpack>=0.5.6',
         'msgpack-numpy>=0.4.4',
-        'pyzmq>=17.1.2',
+        'pyzmq>=22.3.0',
         'pyFAI>=0.17.0',
         'PyQt5==5.13.2',
         'PyQt5-sip>=12.9.0',


### PR DESCRIPTION
See the commit message for details. This is the script I used to reproduce the issue outside of extra-foam:
```python
#! python3

import gc
import sys
import signal

import zmq
from karabo_bridge import Client


def exit_handler(*_):
    print("\nExiting")
    sys.exit(0)

if __name__ == "__main__":
    signal.signal(signal.SIGINT, exit_handler)

    client = Client("tcp://127.0.0.1:45454")

    while True:
        client.next()
        # gc.collect()
        print("Received data")
```

Fixes #313.