### PR TITLE
Add support for streaming detector data and normalizing by user-defined 2D pipeline sources

### DIFF
--- a/docs/image_tool.rst
+++ b/docs/image_tool.rst
@@ -151,9 +151,18 @@ ROI histogram setup
 ROI normalizer setup
 """"""""""""""""""""
 
+The settings for this are on the *ROI normalizer settings* tab. The
+normalization source can either be the main detector, or some other 2D source
+image. To use a different source, such as a camera, add it as a pipeline source
+(purple square) in the :ref:`Data source tree` under the *User-defined* section,
+and if it is a 2D image it will be displayed as an option in the *ROI source*
+list.
+
 +----------------------------+--------------------------------------------------------------------+
 | Input                      | Description                                                        |
 +============================+====================================================================+
+| ``ROI source``             | Source to compute the normalization factor from.                   |
++----------------------------+--------------------------------------------------------------------+
 | ``Combo``                  | ROI combination, e.g. *ROI3*, *ROI4*, *ROI3 + ROI4*, *ROI3 - ROI4*.|
 +----------------------------+--------------------------------------------------------------------+
 | ``FOM``                    | ROI FOM type, e.g. *SUM*, *MEAN*, *MEDIAN*, *MIN*, *MAX*.          |

--- a/docs/main_gui.rst
+++ b/docs/main_gui.rst
@@ -1,5 +1,3 @@
-
-
 MAIN GUI
 ========
 
@@ -261,3 +259,39 @@ When right-clicking the name of a snapshot, a context menu will show up:
 
     *Analysis setup manager* is still in the testing phase and we are collecting feedbacks from users.
     It should be noted that there is no backup recovery mechanism for now.
+
+
+Extensions
+-----------
+
+On the left hand side there is a tab bar, one for the main GUI and the second
+for the extensions settings:
+
+.. image:: images/extensions.png
+
+EXtra-foam supports streaming the processed data in two ways:
+
+1. All processed data may be streamed to a :ref:`Special analysis suite`.
+2. Just the processed and averaged detector image may be streamed over a Karabo
+   bridge. This is could be helpful if, for example, an experiment requires using
+   two detectors simultaneously. In this case EXtra-foam could be set up to read
+   data from both a trainmatcher/Karabo bridge hosted in Karabo and another
+   EXtra-foam instance. To get the detector data from a Karabo bridge client,
+   use the key ``EF_<source_name>``, where ``source_name`` is the source name of the
+   main detector. For example, if streaming ePix data from the device
+   ``MID_EXP_EPIX-2/DET/RECEIVER:output`` with property ``data.image``, use
+   ``EF_MID_EXP_EPIX-2/DET/RECEIVER:output`` and ``data.image`` at the client.
+
+.. warning::
+
+    There are limited use-cases for streaming detector data to another
+    EXtra-foam instance, contact da-support@xfel.eu if you would like to do
+    this.
+
++-----------------------------+--------------------------------------------------------------------+
+| Input                       | Description                                                        |
++=============================+====================================================================+
+| ``Special suite port``      | Port to use for streaming data for the special suites.             |
++-----------------------------+--------------------------------------------------------------------+
+| ``Detector streaming port`` | Port to use for streaming the processed 2D detector image.         |
++-----------------------------+--------------------------------------------------------------------+

--- a/docs/special_suite.rst
+++ b/docs/special_suite.rst
@@ -1,3 +1,5 @@
+.. _special analysis suite:
+
 SPECIAL ANALYSIS SUITE
 ======================
 

--- a/extra_foam/config.py
+++ b/extra_foam/config.py
@@ -32,6 +32,11 @@ class DataSource(IntEnum):
     UNKNOWN = 2  # not specified
 
 
+class KaraboType(IntEnum):
+    CONTROL_DATA = 0
+    PIPELINE_DATA = 1
+
+
 class PumpProbeMode(IntEnum):
     UNDEFINED = 0
     REFERENCE_AS_OFF = 1  # use pre-defined reference image

--- a/extra_foam/config.py
+++ b/extra_foam/config.py
@@ -7,7 +7,7 @@ Author: Jun Zhu <jun.zhu@xfel.eu>
 Copyright (C) European X-Ray Free-Electron Laser Facility GmbH.
 All rights reserved.
 """
-from enum import IntEnum
+from enum import Enum, IntEnum
 import os.path as osp
 import shutil
 from collections import abc, namedtuple, OrderedDict
@@ -24,6 +24,11 @@ from .logger import logger
 
 _MAX_INT32 = np.iinfo(np.int32).max
 _MIN_INT32 = np.iinfo(np.int32).min
+
+
+class ExtensionType(Enum):
+    ALL_OUTPUT = "endpoint"
+    DETECTOR_OUTPUT = "detector_endpoint"
 
 
 class DataSource(IntEnum):

--- a/extra_foam/database/data_source.py
+++ b/extra_foam/database/data_source.py
@@ -144,3 +144,7 @@ class SourceCatalog(abc.Collection):
     def __repr__(self):
         return f'SourceCatalog(main_detector={self._main_detector}, ' \
                f'n_items={self.__len__()})'
+
+    def __eq__(self, other):
+        return self._items == other._items and \
+            self.main_detector == other.main_detector

--- a/extra_foam/database/data_source.py
+++ b/extra_foam/database/data_source.py
@@ -19,7 +19,7 @@ from ..config import config
 # modules: a list of module indices
 # slicer: pulse slicer for pulse-resolved data
 # vrange: value range
-# ktype: Karabo data type, 1 for pipeline data and 0 for control data
+# ktype: KaraboType
 SourceItem = namedtuple(
     'SourceItem',
     ['category', 'name', 'modules', 'property', 'slicer', 'vrange', 'ktype'])

--- a/extra_foam/gui/ctrl_widgets/data_source_widget.py
+++ b/extra_foam/gui/ctrl_widgets/data_source_widget.py
@@ -26,7 +26,7 @@ from ..gui_helpers import parse_boundary, parse_slice
 from ..misc_widgets import FColor
 from ..mediator import Mediator
 from ...database import MonProxy
-from ...config import config, DataSource
+from ...config import config, DataSource, KaraboType
 from ...geometries import module_indices
 from ...processes import list_foam_processes
 from ...logger import logger
@@ -395,7 +395,7 @@ class DataSourceItemModel(QAbstractItemModel):
                 for ppt in ppts:
                     # For now, all pipeline data are exclusive
                     src_item = DataSourceTreeItem(
-                        [False, 1, src, ppt, default_slicer, default_v_range],
+                        [False, KaraboType.PIPELINE_DATA, src, ppt, default_slicer, default_v_range],
                         exclusive=True,
                         parent=ctg_item)
                     ctg_item.appendChild(src_item)
@@ -416,7 +416,7 @@ class DataSourceItemModel(QAbstractItemModel):
             for src, ppts in srcs.items():
                 for ppt in ppts:
                     ctg_item.appendChild(DataSourceTreeItem(
-                        [False, 0, src, ppt, default_slicer, default_v_range],
+                        [False, KaraboType.CONTROL_DATA, src, ppt, default_slicer, default_v_range],
                         exclusive=False,
                         parent=ctg_item))
 
@@ -701,10 +701,9 @@ class DataSourceWidget(_AbstractCtrlWidget):
             if isinstance(v, int):
                 painter.setPen(Qt.NoPen)
 
-                if v == 0:
-                    # control data
+                if v == KaraboType.CONTROL_DATA:
                     painter.setBrush(self._c_brush)
-                elif v == 1:
+                elif v == KaraboType.PIPELINE_DATA:
                     # pipeline data
                     painter.setBrush(self._p_brush)
                 else:

--- a/extra_foam/gui/ctrl_widgets/data_source_widget.py
+++ b/extra_foam/gui/ctrl_widgets/data_source_widget.py
@@ -439,8 +439,9 @@ class DataSourceItemModel(QAbstractItemModel):
                                       parent=self._root)
         self._root.appendChild(ctg_item)
         for i in range(n_user_defined):
+            dtype = KaraboType.PIPELINE_DATA if i < n_user_defined / 2 else KaraboType.CONTROL_DATA
             ctg_item.appendChild(DataSourceTreeItem(
-                [False, 0, f"Device-ID-{i+1}", f"Property-{i+1}",
+                [False, dtype, f"Device-ID-{i+1}", f"Property-{i+1}",
                  "", '-inf, inf'],
                 exclusive=False,
                 parent=ctg_item))

--- a/extra_foam/gui/ctrl_widgets/extension_ctrl_widget.py
+++ b/extra_foam/gui/ctrl_widgets/extension_ctrl_widget.py
@@ -14,6 +14,7 @@ from PyQt5.QtWidgets import QGridLayout, QLabel
 from .base_ctrl_widgets import _AbstractGroupBoxCtrlWidget
 from .smart_widgets import SmartLineEdit
 from ...config import config
+from ...utils import get_available_port
 
 
 class ExtensionCtrlWidget(_AbstractGroupBoxCtrlWidget):
@@ -24,7 +25,7 @@ class ExtensionCtrlWidget(_AbstractGroupBoxCtrlWidget):
 
         self._host_le = SmartLineEdit('*')
         self._host_le.setEnabled(False)
-        self._port_le = SmartLineEdit(str(config["EXTENSION_PORT"]))
+        self._port_le = SmartLineEdit(str(get_available_port(config["EXTENSION_PORT"])))
         self._port_le.setValidator(QIntValidator(0, 65535))
 
         self._non_reconfigurable_widgets = [

--- a/extra_foam/gui/ctrl_widgets/extension_ctrl_widget.py
+++ b/extra_foam/gui/ctrl_widgets/extension_ctrl_widget.py
@@ -23,13 +23,18 @@ class ExtensionCtrlWidget(_AbstractGroupBoxCtrlWidget):
     def __init__(self, *args, **kwargs):
         super().__init__("Extension setup", *args, **kwargs)
 
+        extension_port = get_available_port(config["EXTENSION_PORT"])
+
         self._host_le = SmartLineEdit('*')
         self._host_le.setEnabled(False)
-        self._port_le = SmartLineEdit(str(get_available_port(config["EXTENSION_PORT"])))
+        self._port_le = SmartLineEdit(str(extension_port))
         self._port_le.setValidator(QIntValidator(0, 65535))
+
+        self._detector_port_le = SmartLineEdit(str(get_available_port(extension_port + 1)))
 
         self._non_reconfigurable_widgets = [
             self._port_le,
+            self._detector_port_le
         ]
 
         self.initUI()
@@ -44,8 +49,10 @@ class ExtensionCtrlWidget(_AbstractGroupBoxCtrlWidget):
 
         layout.addWidget(QLabel("IP address"), 0, 0, AR)
         layout.addWidget(self._host_le, 0, 1)
-        layout.addWidget(QLabel("Port"), 0, 2, AR)
+        layout.addWidget(QLabel("Special suite port"), 0, 2, AR)
         layout.addWidget(self._port_le, 0, 3)
+        layout.addWidget(QLabel("Detector streaming port"), 1, 2, AR)
+        layout.addWidget(self._detector_port_le, 1, 3)
 
         self.setLayout(layout)
 
@@ -53,6 +60,7 @@ class ExtensionCtrlWidget(_AbstractGroupBoxCtrlWidget):
         """Overload."""
         self._host_le.returnPressed.connect(self._onEndpointChange)
         self._port_le.returnPressed.connect(self._onEndpointChange)
+        self._detector_port_le.returnPressed.connect(self._onEndpointChange)
 
     def updateMetaData(self):
         """Overload."""
@@ -67,3 +75,5 @@ class ExtensionCtrlWidget(_AbstractGroupBoxCtrlWidget):
     def _onEndpointChange(self):
         self._mediator.onExtensionEndpointChange(
             f"tcp://{self._host_le.text()}:{self._port_le.text()}")
+        self._mediator.onDetectorExtensionEndpointChange(
+            f"tcp://{self._host_le.text()}:{self._detector_port_le.text()}")

--- a/extra_foam/gui/image_tool/image_tool.py
+++ b/extra_foam/gui/image_tool/image_tool.py
@@ -233,12 +233,14 @@ class ImageToolWindow(QMainWindow, _AbstractWindowMixin):
     def _updateWidgets(self, auto_update):
         if len(self._queue) == 0:
             return
+
         data = self._queue[0]
+        processed = data["processed"]
 
         # update bulletin
-        self._bulletin_view.updateF(data, auto_update)
+        self._bulletin_view.updateF(processed, auto_update)
         # update other ImageView/PlotWidget in the activated tab
-        self._views_tab.currentWidget().updateF(data, auto_update)
+        self._views_tab.currentWidget().updateF(processed, auto_update)
 
     @pyqtSlot(int)
     def onViewsTabClicked(self, idx):

--- a/extra_foam/gui/image_tool/image_tool.py
+++ b/extra_foam/gui/image_tool/image_tool.py
@@ -239,8 +239,13 @@ class ImageToolWindow(QMainWindow, _AbstractWindowMixin):
 
         # update bulletin
         self._bulletin_view.updateF(processed, auto_update)
-        # update other ImageView/PlotWidget in the activated tab
-        self._views_tab.currentWidget().updateF(processed, auto_update)
+        # Update other ImageViews/PlotWidgets in the activated tab. The
+        # CorrectedView needs all the data, so we treat it differently from the
+        # others.
+        if self._views_tab.currentIndex() == self.TabIndex.OVERVIEW:
+            self._views_tab.currentWidget().updateF(data, auto_update)
+        else:
+            self._views_tab.currentWidget().updateF(processed, auto_update)
 
     @pyqtSlot(int)
     def onViewsTabClicked(self, idx):

--- a/extra_foam/gui/image_tool/tests/test_image_tool.py
+++ b/extra_foam/gui/image_tool/tests/test_image_tool.py
@@ -476,13 +476,14 @@ class TestImageTool(unittest.TestCase, _TestDataMixin):
                 self.assertIsNone(ref)
 
     def testBulletinView(self):
-        processed = ProcessedData(1357)
+        data = self.empty_data(1357)
+        processed = data["processed"]
 
         processed.image = ImageData.from_array(np.ones((10, 4, 4), np.float32))
         processed.image.dark_count = 99
         processed.image.n_dark_pulses = 10
         processed.pidx.mask_by_index([1, 3, 5, 6])
-        self.gui._queue.append(processed)
+        self.gui._queue.append(data)
         self.image_tool.updateWidgetsF()
 
         view = self.image_tool._bulletin_view

--- a/extra_foam/gui/image_tool/tests/test_image_tool.py
+++ b/extra_foam/gui/image_tool/tests/test_image_tool.py
@@ -142,7 +142,7 @@ class TestImageTool(unittest.TestCase, _TestDataMixin):
     def testRoiCtrlWidget(self):
         roi_ctrls = self.image_tool._corrected_view._roi_ctrl_widget._roi_ctrls
         proc = self.pulse_worker._image_roi
-        self.assertEqual(4, len(roi_ctrls))
+        self.assertEqual(2, len(roi_ctrls))
 
         # test default
 
@@ -840,17 +840,23 @@ class TestImageTool(unittest.TestCase, _TestDataMixin):
         self.assertEqual(RoiFom.SUM, proc._norm_type)
 
         # test setting new values
+        raw_detector_name = "Foo"
+        widget.updateOptions([raw_detector_name])
+        widget._source_cb.setCurrentText(raw_detector_name)
         widget._combo_cb.setCurrentText(avail_combos[RoiCombo.ROI3_ADD_ROI4])
         widget._type_cb.setCurrentText(avail_types[RoiFom.MEDIAN])
         proc.update()
         self.assertEqual(RoiCombo.ROI3_ADD_ROI4, proc._norm_combo)
         self.assertEqual(RoiFom.MEDIAN, proc._norm_type)
+        self.assertEqual(raw_detector_name, proc._norm_source)
 
         # test loading meta data
         mediator = widget._mediator
+        mediator.onRoiNormSourceChange(config["DETECTOR"])
         mediator.onRoiNormComboChange(RoiCombo.ROI3_SUB_ROI4)
         mediator.onRoiNormTypeChange(RoiProjType.SUM)
         widget.loadMetaData()
+        self.assertEqual(config["DETECTOR"], widget._source_cb.currentText())
         self.assertEqual("ROI3 - ROI4", widget._combo_cb.currentText())
         self.assertEqual("SUM", widget._type_cb.currentText())
 

--- a/extra_foam/gui/image_tool/tests/test_views.py
+++ b/extra_foam/gui/image_tool/tests/test_views.py
@@ -37,6 +37,8 @@ class TestViews(_TestDataMixin, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.gui = cls.MockedImageToolWindow()
+        cls._empty_data = cls.empty_data()
+        cls._data, _ = cls.data_with_assembled(1001, (2, 2), roi_histogram=True)
 
     @classmethod
     def tearDownClass(cls):
@@ -49,23 +51,19 @@ class TestViews(_TestDataMixin, unittest.TestCase):
         view = CorrectedView(pulse_resolved=True, parent=self.gui)
 
         # empty data
-        data = ProcessedData(1)
-        view.updateF(data, True)
+        view.updateF(self._empty_data, True)
 
         # non-empty data
-        data = self.processed_data(1001, (2, 2), roi_histogram=True)
-        view.updateF(data, True)
+        view.updateF(self._data, True)
 
         # train-resolved
 
         view = CorrectedView(pulse_resolved=False, parent=self.gui)
         # empty data
-        data = ProcessedData(1)
-        view.updateF(data, True)
+        view.updateF(self._empty_data, True)
 
         # non-empty data
-        data = self.processed_data(1001, (2, 2), roi_histogram=True)
-        view.updateF(data, True)
+        view.updateF(self._data, True)
 
     def testAzimuthalIntegrationView(self):
 

--- a/extra_foam/gui/main_gui.py
+++ b/extra_foam/gui/main_gui.py
@@ -331,8 +331,8 @@ class MainGUI(QMainWindow):
             return
 
         try:
-            processed = self._input.get()
-            self._queue.append(processed)
+            data = self._input.get()
+            self._queue.append(data)
         except Empty:
             return
 
@@ -340,7 +340,7 @@ class MainGUI(QMainWindow):
         # for w in self._plot_windows.keys():
         #     w.reset()
 
-        data = self._queue[0]
+        processed = self._queue[0]["processed"]
 
         self._image_tool.updateWidgetsF()
         for w in itertools.chain(self._plot_windows):
@@ -352,7 +352,7 @@ class MainGUI(QMainWindow):
                              + repr(e))
                 logger.error(f"[Update plots] {repr(e)}")
 
-        logger.debug(f"Plot train with ID: {data.tid}")
+        logger.debug(f"Plot train with ID: {processed.tid}")
 
     def pingRedisServer(self):
         try:

--- a/extra_foam/gui/mediator.py
+++ b/extra_foam/gui/mediator.py
@@ -248,6 +248,9 @@ class Mediator(QObject):
     def onRoiHistBinRangeChange(self, value: tuple):
         self._meta.hset(mt.ROI_PROC, "hist:bin_range", str(value))
 
+    def onRoiNormSourceChange(self, value: str):
+        self._meta.hset(mt.ROI_PROC, "norm:source", value)
+
     def onRoiNormTypeChange(self, value: IntEnum):
         self._meta.hset(mt.ROI_PROC, 'norm:type', int(value))
 

--- a/extra_foam/gui/mediator.py
+++ b/extra_foam/gui/mediator.py
@@ -12,6 +12,7 @@ import json
 
 from PyQt5.QtCore import pyqtSignal,  QObject
 
+from ..config import ExtensionType
 from ..database import Metadata as mt
 from ..database import MetaProxy
 
@@ -60,7 +61,10 @@ class Mediator(QObject):
         self._meta.unregister_analysis(analysis_type)
 
     def onExtensionEndpointChange(self, endpoint: str):
-        self._meta.hset(mt.EXTENSION, "endpoint", endpoint)
+        self._meta.hset(mt.EXTENSION, ExtensionType.ALL_OUTPUT.value, endpoint)
+
+    def onDetectorExtensionEndpointChange(self, endpoint: str):
+        self._meta.hset(mt.EXTENSION, ExtensionType.DETECTOR_OUTPUT.value, endpoint)
 
     def onBridgeConnectionsChange(self, connections: dict):
         # key = endpoint, value = source type

--- a/extra_foam/gui/windows/binning_w.py
+++ b/extra_foam/gui/windows/binning_w.py
@@ -42,7 +42,7 @@ class Bin1dHist(TimedPlotWidgetF):
 
     def refresh(self):
         """Override."""
-        item = self._data.bin[0]
+        item = self._data["processed"].bin[0]
 
         src = item.source
         if src != self._source:
@@ -89,7 +89,7 @@ class Bin1dHeatmap(TimedImageViewF):
 
     def refresh(self):
         """Override."""
-        item = self._data.bin[0]
+        item = self._data["processed"].bin[0]
 
         src = item.source
         if src != self._source:
@@ -163,7 +163,7 @@ class Bin2dHeatmap(TimedImageViewF):
 
     def refresh(self):
         """Override."""
-        bin = self._data.bin
+        bin = self._data["processed"].bin
 
         src_x = bin[0].source
         if src_x != self._source_x:

--- a/extra_foam/gui/windows/correlation_w.py
+++ b/extra_foam/gui/windows/correlation_w.py
@@ -47,7 +47,7 @@ class CorrelationPlot(TimedPlotWidgetF):
 
     def refresh(self):
         """Override."""
-        item = self._data.corr[self._idx]
+        item = self._data["processed"].corr[self._idx]
 
         src = item.source
         if src != self._source:

--- a/extra_foam/gui/windows/histogram_w.py
+++ b/extra_foam/gui/windows/histogram_w.py
@@ -36,7 +36,7 @@ class InTrainFomPlot(PlotWidgetF):
 
     def updateF(self, data):
         """Override."""
-        foms = data.pulse.hist.pulse_foms
+        foms = data["processed"].pulse.hist.pulse_foms
         if foms is None:
             self.reset()
         else:
@@ -62,7 +62,7 @@ class FomHist(HistMixin, TimedPlotWidgetF):
 
     def refresh(self):
         """Override."""
-        hist = self._data.hist
+        hist = self._data["processed"].hist
         bin_centers = hist.bin_centers
         if bin_centers is None:
             self.reset()

--- a/extra_foam/gui/windows/pulse_of_interest_w.py
+++ b/extra_foam/gui/windows/pulse_of_interest_w.py
@@ -31,14 +31,16 @@ class PoiImageView(ImageViewF):
 
     def updateF(self, data):
         """Override."""
+        processed = data["processed"]
+
         try:
-            img = data.image.images[self._index]
+            img = processed.image.images[self._index]
             self.setImage(img, auto_levels=(not self._is_initialized))
         except (IndexError, TypeError):
             self.clear()
             return
 
-        self.updateROI(data)
+        self.updateROI(processed)
 
         if not self._is_initialized:
             self._is_initialized = True
@@ -69,7 +71,7 @@ class PoiFomHist(HistMixin, TimedPlotWidgetF):
     def refresh(self):
         """Override."""
         try:
-            hist = self._data.pulse.hist[self._index]
+            hist = self._data["processed"].pulse.hist[self._index]
         except KeyError:
             self.reset()
         else:
@@ -102,7 +104,7 @@ class PoiRoiHist(HistMixin, PlotWidgetF):
     def updateF(self, data):
         """Override."""
         try:
-            hist = data.pulse.roi.hist[self._index]
+            hist = data["processed"].pulse.roi.hist[self._index]
         except KeyError:
             self.reset()
         else:

--- a/extra_foam/gui/windows/pump_probe_w.py
+++ b/extra_foam/gui/windows/pump_probe_w.py
@@ -47,7 +47,7 @@ class PumpProbeVFomPlot(PlotWidgetF):
 
     def updateF(self, data):
         """Override."""
-        pp = data.pp
+        pp = data["processed"].pp
         x, y = pp.x, pp.y
 
         if self._analysis_type != pp.analysis_type:
@@ -86,7 +86,7 @@ class PumpProbeFomPlot(TimedPlotWidgetF):
 
     def refresh(self):
         """Override."""
-        pp = self._data.corr.pp
+        pp = self._data["processed"].corr.pp
         x, y = pp.x, pp.y
         self._plot.setData(x, y)
 

--- a/extra_foam/gui/windows/tests/test_plot_widgets.py
+++ b/extra_foam/gui/windows/tests/test_plot_widgets.py
@@ -12,28 +12,36 @@ app = mkQApp()
 logger.setLevel('CRITICAL')
 
 
-class testPumpProbeWidgets(unittest.TestCase):
+class testPumpProbeWidgets(_TestDataMixin, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._data = cls.empty_data()
+
     def testPumpProbeVFomPlot(self):
         from extra_foam.gui.windows.pump_probe_w import PumpProbeVFomPlot
 
         widget = PumpProbeVFomPlot()
-        data = ProcessedData(1)
-        widget.updateF(data)
+        widget.updateF(self._data)
 
     def testPumpProbeFomPlot(self):
         from extra_foam.gui.windows.pump_probe_w import PumpProbeFomPlot
 
         widget = PumpProbeFomPlot()
-        widget._data = ProcessedData(1)
+        widget._data = self._data
         widget.refresh()
 
 
 class testPulseOfInterestWidgets(_TestDataMixin, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._empty_data = cls.empty_data()
+        cls._data, _ = cls.data_with_assembled(1001, (4, 2, 2), histogram=True)
+
     def testPoiImageView(self):
         from extra_foam.gui.windows.pulse_of_interest_w import PoiImageView
 
         widget = PoiImageView(0)
-        data = ProcessedData(1)
+        data = self._empty_data
         widget.updateF(data)
 
     def testPoiFomHist(self):
@@ -42,11 +50,11 @@ class testPulseOfInterestWidgets(_TestDataMixin, unittest.TestCase):
         widget = PoiFomHist(0)
 
         # empty data
-        widget._data = ProcessedData(1)
+        widget._data = self._empty_data
         widget.refresh()
 
         # non-empty data
-        widget._data = self.processed_data(1001, (4, 2, 2), histogram=True)
+        widget._data = self._data
         widget.refresh()
 
     def testPoiRoiHist(self):
@@ -55,20 +63,24 @@ class testPulseOfInterestWidgets(_TestDataMixin, unittest.TestCase):
         widget = PoiRoiHist(0)
 
         # empty data
-        data = ProcessedData(1)
+        data = self._empty_data
         widget.updateF(data)
 
         # non-empty data
-        data = self.processed_data(1001, (4, 2, 2), histogram=True)
+        data = self._data
         widget.updateF(data)
 
 
-class testBinningWidgets(unittest.TestCase):
+class testBinningWidgets(_TestDataMixin, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._empty_data = cls.empty_data()
+
     def testBin1dHist(self):
         from extra_foam.gui.windows.binning_w import Bin1dHist
 
         widget = Bin1dHist()
-        widget._data = ProcessedData(1)
+        widget._data = self._empty_data
 
         widget.refresh()
 
@@ -76,7 +88,7 @@ class testBinningWidgets(unittest.TestCase):
         from extra_foam.gui.windows.binning_w import Bin1dHeatmap
 
         widget = Bin1dHeatmap()
-        widget._data = ProcessedData(1)
+        widget._data = self._empty_data
 
         # test "Auto level" reset
         widget._auto_level = True
@@ -88,7 +100,7 @@ class testBinningWidgets(unittest.TestCase):
 
         for is_count in [False, True]:
             widget = Bin2dHeatmap(count=is_count)
-            widget._data = ProcessedData(1)
+            widget._data = self._empty_data
 
             # test "Auto level" reset
             widget._auto_level = True
@@ -97,12 +109,17 @@ class testBinningWidgets(unittest.TestCase):
 
 
 class testCorrrelationWidgets(_TestDataMixin, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._empty_data = cls.empty_data()
+        cls._data, _ = cls.data_with_assembled(1001, (4, 2, 2), correlation=True)
+
     def testGeneral(self):
         from extra_foam.gui.windows.correlation_w import CorrelationPlot
 
         for i in range(2):
             widget = CorrelationPlot(0)
-            widget._data = ProcessedData(1)
+            widget._data = self._empty_data
             widget.refresh()
 
     def testResolutionSwitch(self):
@@ -110,10 +127,8 @@ class testCorrrelationWidgets(_TestDataMixin, unittest.TestCase):
         from extra_foam.gui.plot_widgets.plot_items import StatisticsBarItem, pg
 
         # resolution1 = 0.0 and resolution2 > 0.0
-        data = self.processed_data(1001, (4, 2, 2), correlation=True)
-
         widget = CorrelationPlot(0)
-        widget._data = data
+        widget._data = self._data
         widget.refresh()
         plot_item, plot_item_slave = widget._plot, widget._plot_slave
         self.assertIsInstance(plot_item, ScatterPlotItem)
@@ -129,7 +144,7 @@ class testCorrrelationWidgets(_TestDataMixin, unittest.TestCase):
         self.assertEqual(2, plot_item._beam)
         self.assertEqual(2, plot_item_slave._beam)
         # beam size changes with resolution
-        widget._data.corr[1].resolution = 4
+        widget._data["processed"].corr[1].resolution = 4
         widget.refresh()
         self.assertEqual(4, plot_item._beam)
         self.assertEqual(4, plot_item_slave._beam)
@@ -143,22 +158,27 @@ class testCorrrelationWidgets(_TestDataMixin, unittest.TestCase):
 
 
 class testHistogramWidgets(_TestDataMixin, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._empty_data = cls.empty_data()
+        cls._data, _ = cls.data_with_assembled(1001, (4, 2, 2), histogram=True)
+
     def testFomHist(self):
         from extra_foam.gui.windows.histogram_w import FomHist
 
         widget = FomHist()
 
         # empty data
-        widget._data = ProcessedData(1)
+        widget._data = self._empty_data
         widget.refresh()
 
         # non-empty data
-        widget._data = self.processed_data(1001, (4, 2, 2), histogram=True)
+        widget._data = self._data
         widget.refresh()
 
     def testInTrainFomPlot(self):
         from extra_foam.gui.windows.histogram_w import InTrainFomPlot
 
         widget = InTrainFomPlot()
-        data = ProcessedData(1)
+        data = self._empty_data
         widget.updateF(data)

--- a/extra_foam/pipeline/f_pipe.py
+++ b/extra_foam/pipeline/f_pipe.py
@@ -297,24 +297,24 @@ class MpOutQueue(_PipeOutBase):
 
             if data_out is None:
                 try:
-                    data = self._cache.get_nowait()
+                    data_out = self._cache.get_nowait()
 
                     if self._final:
-                        data_out = data['processed']
+                        processed = data_out['processed']
 
-                        tid = data_out.tid
-                        n_pulses = data_out.pidx.n_kept(data_out.n_pulses)
+                        tid = processed.tid
+                        n_pulses = processed.pidx.n_kept(processed.n_pulses)
                         self._mon.add_tid_with_timestamp(
                             tid, n_pulses=n_pulses)
 
                         logger.info(f"Train {tid} processed!")
 
-                        if data.get("reset_ma", False):
+                        if data_out.get("reset_ma", False):
                             self._meta.hset(mt.GLOBAL_PROC, "reset_ma", 1)
                         else:
                             self._meta.hdel(mt.GLOBAL_PROC, "reset_ma")
                     else:
-                        data_out = {key: data[key] for key
+                        data_out = {key: data_out[key] for key
                                     in self._pipeline_dtype}
                 except Empty:
                     pass

--- a/extra_foam/pipeline/f_transformer.py
+++ b/extra_foam/pipeline/f_transformer.py
@@ -70,8 +70,7 @@ class DataTransformer:
 
             if modules:
                 prefix, suffix = src_name.split("*")
-                new_raw[src] = dict()
-                module_data = new_raw[src]
+                module_data = dict()
                 n_found = 0
                 for idx in modules:
                     module_name = f"{prefix}{idx}{suffix}"
@@ -83,6 +82,7 @@ class DataTransformer:
                     # there is no module data
                     continue
                 else:
+                    new_raw[src] = module_data
                     new_meta[src] = {
                         'train_id': tid, 'source_type': source_type,
                     }

--- a/extra_foam/pipeline/processors/control_data.py
+++ b/extra_foam/pipeline/processors/control_data.py
@@ -8,7 +8,7 @@ Copyright (C) European X-Ray Free-Electron Laser Facility GmbH.
 All rights reserved.
 """
 from .base_processor import _BaseProcessor
-from ...config import config
+from ...config import config, KaraboType
 
 
 class CtrlDataProcessor(_BaseProcessor):
@@ -39,6 +39,11 @@ class CtrlDataProcessor(_BaseProcessor):
 
             # process control data
             for src in srcs:
+                # Double-check that the source is control data, this is
+                # particularly needed for the user-defined keys.
+                if not catalog.get_type(src) == KaraboType.CONTROL_DATA:
+                    continue
+
                 v = raw[src]
                 self.filter_train_by_vrange(
                     v, catalog.get_vrange(src), src)

--- a/extra_foam/pipeline/processors/tests/test_ctrl_data.py
+++ b/extra_foam/pipeline/processors/tests/test_ctrl_data.py
@@ -13,7 +13,7 @@ from extra_foam.pipeline.tests import _TestDataMixin
 from extra_foam.pipeline.processors.control_data import CtrlDataProcessor
 from extra_foam.database import SourceItem
 from extra_foam.pipeline.exceptions import SkipTrainError
-from extra_foam.config import config
+from extra_foam.config import config, KaraboType
 
 
 class TestCtrlData(_TestDataMixin, unittest.TestCase):
@@ -26,7 +26,7 @@ class TestCtrlData(_TestDataMixin, unittest.TestCase):
         catalog = data['catalog']
 
         for ctg in ['Motor', 'Monochromator', 'Magnet', config["SOURCE_USER_DEFINED_CATEGORY"]]:
-            item = SourceItem(ctg, 'device1', [], 'property1', None, (-1, 1), 0)
+            item = SourceItem(ctg, 'device1', [], 'property1', None, (-1, 1), KaraboType.CONTROL_DATA)
             catalog.add_item(item)
             src = f"{item.name} {item.property}"
             meta[src] = {'train_id': 12346}
@@ -38,7 +38,7 @@ class TestCtrlData(_TestDataMixin, unittest.TestCase):
 
         catalog.clear()
         for ctg in ['XGM', 'DSSC', 'JungFrau']:
-            item = SourceItem(ctg, 'device1', [], 'property1', None, (-1, 1), 1)
+            item = SourceItem(ctg, 'device1', [], 'property1', None, (-1, 1), KaraboType.PIPELINE_DATA)
             catalog.add_item(item)
             src = f"{item.name} {item.property}"
             meta[src] = {'train_id': 12346}

--- a/extra_foam/pipeline/processors/tests/test_ctrl_data.py
+++ b/extra_foam/pipeline/processors/tests/test_ctrl_data.py
@@ -37,11 +37,12 @@ class TestCtrlData(_TestDataMixin, unittest.TestCase):
                 proc.process(data)
 
         catalog.clear()
-        for ctg in ['XGM', 'DSSC', 'JungFrau']:
+        for ctg in ['XGM', 'DSSC', 'JungFrau', config["SOURCE_USER_DEFINED_CATEGORY"]]:
             item = SourceItem(ctg, 'device1', [], 'property1', None, (-1, 1), KaraboType.PIPELINE_DATA)
             catalog.add_item(item)
             src = f"{item.name} {item.property}"
             meta[src] = {'train_id': 12346}
             raw[src] = 2
-            # it will not raise for other sources
+            # It will not raise for other sources, even the user-defined
+            # category, which may be pipeline data.
             proc.process(data)

--- a/extra_foam/pipeline/tests/__init__.py
+++ b/extra_foam/pipeline/tests/__init__.py
@@ -26,6 +26,10 @@ class _TestDataMixin:
         return imgs
 
     @classmethod
+    def empty_data(cls, tid=1):
+        return cls.simple_data(tid, (10, 10))[0]
+
+    @classmethod
     def simple_data(cls, tid, shape, *,
                     src_type=DataSource.BRIDGE,
                     dtype=config['SOURCE_PROC_IMAGE_DTYPE'],
@@ -45,12 +49,16 @@ class _TestDataMixin:
                             slicer=None,
                             with_xgm=False,
                             with_digitizer=False,
+                            roi_histogram=False,
+                            histogram=False,
+                            correlation=False,
+                            binning=False,
                             **kwargs):
         imgs = cls._gen_images(gen, shape, dtype)
-
-        processed = ProcessedData(tid)
-
-        processed.image = ImageData.from_array(imgs, **kwargs)
+        processed = cls.processed_data(tid, shape, gen=gen, dtype=dtype,
+                                       roi_histogram=roi_histogram, histogram=histogram,
+                                       correlation=correlation, binning=binning,
+                                       **kwargs)
 
         if imgs.ndim == 2:
             slicer = None

--- a/extra_foam/pipeline/tests/test_transformer.py
+++ b/extra_foam/pipeline/tests/test_transformer.py
@@ -12,6 +12,9 @@ class TestDataTransformer(_RawDataMixin, unittest.TestCase):
         src_type = DataSource.BRIDGE
 
         catalog = self._create_catalog({'ABC': [('abc', 'ppt', 0)]})
+        # Add a module source to ensure that the transformer can properly handle
+        # trains that don't include all module data.
+        catalog.add_item(SourceItem('XYZ', 'xyz_*:xtdf', [1, 2], 'ppt', slice(None, None), [0, 100], 1))
 
         # no data is available
         data = (dict(), dict())  # raw, meta

--- a/extra_foam/pipeline/tests/test_worker.py
+++ b/extra_foam/pipeline/tests/test_worker.py
@@ -1,14 +1,20 @@
 import unittest
+from threading import Thread
 from unittest.mock import MagicMock, patch
 import multiprocessing as mp
 
+from . import _TestDataMixin
 from extra_foam.pipeline.exceptions import ProcessingError, StopPipelineError
 from extra_foam.pipeline.f_worker import TrainWorker, PulseWorker
-from extra_foam.config import config
+from extra_foam.config import config, ExtensionType
+from extra_foam.pipeline.f_zmq import FoamZmqClient
+
+import numpy as np
+from karabo_bridge import Client
 
 
 @patch.dict(config._data, {"DETECTOR": "LPD"})
-class TestWorker(unittest.TestCase):
+class TestWorker(_TestDataMixin, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls._pause_ev = mp.Event()
@@ -49,3 +55,59 @@ class TestWorker(unittest.TestCase):
                 worker._run_tasks({})
             debug.reset_mock()
             error.reset_mock()
+
+            # Check that the extensions are enabled appropriately
+            extensions_enabled = kls == TrainWorker
+            self.assertEqual(worker._extension != None, extensions_enabled)
+            self.assertEqual(worker._detector_extension != None, extensions_enabled)
+
+    @patch('extra_foam.ipc.ProcessLogger.debug')
+    def testExtensions(self, _):
+        worker = TrainWorker(self._pause_ev, self._close_ev)
+
+        # Disable processors
+        worker._run_tasks = MagicMock()
+
+        # Generate mock data
+        mock_data = self.simple_data(1, (10, 10))[0]
+        detector, key = mock_data["catalog"].main_detector.split()
+
+        # Mock the input and output pipes
+        worker._input.start = MagicMock()
+        worker._input.get = MagicMock(return_value=mock_data)
+        worker._output = MagicMock()
+
+        # Mock the database configuration for the extension ZmqOutQueue's
+        extension_endpoint = "ipc://foam-extension"
+        detector_extension_endpoint = "ipc://bridge-extension"
+        worker._extension._meta.hget_all = MagicMock(return_value={ ExtensionType.ALL_OUTPUT.value: extension_endpoint })
+        worker._detector_extension._meta.hget_all = MagicMock(return_value={ ExtensionType.DETECTOR_OUTPUT.value: detector_extension_endpoint })
+
+        # Start worker
+        self._pause_ev.set()
+        worker_thread = Thread(target=worker.run)
+        worker_thread.start()
+
+        # Create clients
+        bridge_client = Client(detector_extension_endpoint, timeout=1)
+        foam_client = FoamZmqClient(extension_endpoint, timeout=1)
+
+        # Test received detector data
+        detector_data, _ = bridge_client.next()
+        np.testing.assert_array_equal(detector_data[f"EF_{detector}"][key],
+                                      mock_data["processed"].image.masked_mean)
+
+        # Test received special suite data
+        foam_data = foam_client.next()
+        for key in foam_data:
+            if key != "processed":
+                self.assertEqual(foam_data[key], mock_data[key])
+            else:
+                # Just comparing the detector image is enough for the
+                # ProcessedData object.
+                np.testing.assert_array_equal(foam_data[key].image.masked_mean,
+                                              mock_data[key].image.masked_mean)
+
+        # Close worker
+        self._close_ev.set()
+        worker_thread.join(timeout=1)

--- a/extra_foam/utils.py
+++ b/extra_foam/utils.py
@@ -9,6 +9,7 @@ All rights reserved.
 """
 import os
 import psutil
+import socket
 import multiprocessing as mp
 import functools
 import subprocess
@@ -261,3 +262,18 @@ def run_in_thread(daemon=False):
             return t
         return threaded_f
     return wrap
+
+
+def get_available_port(default_port):
+    """Find an available port to bind to."""
+    port = default_port
+    with socket.socket() as s:
+        while True:
+            try:
+                s.bind(("127.0.0.1", port))
+            except OSError:
+                port += 1
+            else:
+                break
+
+    return port


### PR DESCRIPTION
There was a request from MID to add support for normalizing stuff by the ePix detector, I decided that the best way to implement this in extra-foam would be by streaming the processed detector data from an ePix instance over a Karabo bridge to the AGIPD instance. This required a number of changes, and I've tried to organize them by commits to make review easier. MID used this successfully during their last experiment.

## How to run it for testing
This is not so easy :grimacing: What you really want is to run a `PipeToZeroMQ` device with two outputs, but in lieu of this I wrote a (truly disgusting) [script](https://gist.github.com/JamesWrigley/62203edd06f12bf66af4cad36cf1954d) that would stream the data from a run to separate ports. In addition, I added a section to the extra-foam config to add a new bridge for the ePix extra-foam instance:
```yml
# Just plonk this somewhere in <instrument>.config.yaml
STREAMER:
    ZMQ:
        EF_ePix100:
          DEFAULT_TYPE: 0
          ADDR: 127.0.0.1
          PORT: 5558
```

With this done, the steps to get the whole thing running are:
1. Start the bridge server:
    ```bash
    $ karabo-bridge-serve-ghidorah
    ```
2. Open the extra-foam instances for the ePix and AGIPD:
    ```bash
    $ extra-foam agipd mid
    $ extra-foam epix mid # Run this in a different terminal
    ```
3. Start the ePix instance.
4. Add a source for the ePix to the AGIPD instance in the 'User-defined' section (see docs)
5. Check that the port of the ePix extension and the source port in the AGIPD instance match, then start the AGIPD instance.
6. The ePix should be listed as an available source under the ROI normalization settings.

You could do this all on Maxwell, but you could also do it locally with a truncated run. I've been testing with proposal 2929, run 149 and I have a truncated 7.7GB version of it lying around that I use for testing (feel free to ping me if you'd like it).

Oversized screenshot of the whole shebang (AGIPD instance on the left, ePix on the right):
![image](https://user-images.githubusercontent.com/5361518/135910940-b1941157-8c07-4204-9973-9c740bb4d888.png)
