### PR TITLE
Test rewrite of the geometry assembler

### DIFF
--- a/src/extra_foam/f_imageproc.cpp
+++ b/src/extra_foam/f_imageproc.cpp
@@ -232,4 +232,46 @@ PYBIND11_MODULE(imageproc, m)
   FOAM_CORRECT_GAIN_AND_OFFSET_IMPL(float, 2)
   FOAM_CORRECT_GAIN_AND_OFFSET_IMPL(double, 3)
   FOAM_CORRECT_GAIN_AND_OFFSET_IMPL(float, 3)
+
+  m.def("assembleDetectorData",                                                                     \
+    &assembleDetectorData<xt::pytensor<float, 4>, xt::pytensor<float, 3>, xt::pytensor<size_t, 1>>, \
+    py::arg("modules").noconvert(), py::arg("assembled").noconvert(), py::arg("lut").noconvert(), py::arg("j"));
+
+  m.def("assembleDetectorData2",                                                                    \
+    &assembleDetectorData2<xt::pytensor<float, 4>, xt::pytensor<float, 3>, xt::pytensor<size_t, 2>>, \
+    py::arg("modules").noconvert(), py::arg("assembled").noconvert(), \
+    py::arg("flat_lut").noconvert(), py::arg("lut_rows").noconvert(), py::arg("lut_cols").noconvert(), \
+    py::arg("tile_rows"), py::arg("tile_cols"));
+
+#define FOAM_GENERATE_ASSEMBLY_LUT(N_DIM) \
+  m.def("generateAssemblyLUT",                                          \
+    [] (size_t data_size, xt::pytensor<double, N_DIM> assembled) { return generateAssemblyLUT(data_size, assembled); }, \
+    py::arg("data_size"), py::arg("assembled").noconvert());
+
+  FOAM_GENERATE_ASSEMBLY_LUT(1)
+  FOAM_GENERATE_ASSEMBLY_LUT(2)
+  FOAM_GENERATE_ASSEMBLY_LUT(3)
+  FOAM_GENERATE_ASSEMBLY_LUT(4)
+
+  m.def("assembleDetectorData3",                                                                    \
+    &assembleDetectorData3<xt::pytensor<float, 4>, xt::pytensor<float, 3>, xt::pytensor<size_t, 2>>, \
+    py::arg("src").noconvert(), py::arg("dest").noconvert(), \
+    py::arg("flat_lut").noconvert(), py::arg("lut_rows").noconvert(), py::arg("lut_cols").noconvert(), \
+    py::arg("tile_rows"), py::arg("tile_cols"));
+
+  m.def("assembleDetectorData4",                                        \
+        &assembleDetectorData4<xt::pytensor<float, 4>, xt::pytensor<float, 3>, xt::pytensor<uint32_t, 1>>, \
+        py::arg("modules").noconvert(), py::arg("assembled").noconvert(), py::arg("lut").noconvert(), py::arg("j"));
+
+  m.def("generateAssemblyLUT2",                                          \
+        [] (size_t data_size, xt::pytensor<double, 2> assembled) { return generateAssemblyLUT2(data_size, assembled); }, \
+        py::arg("data_size"), py::arg("assembled").noconvert());
+
+  m.def("assembleDetectorData5",                                        \
+        &assembleDetectorData5<xt::pytensor<float, 4>, xt::pytensor<float, 3>, xt::pytensor<uint8_t, 1>>, \
+        py::arg("modules").noconvert(), py::arg("assembled").noconvert(), py::arg("lut").noconvert(), py::arg("j"));
+
+ m.def("assembleDetectorData6",                                        \
+        &assembleDetectorData6<xt::pytensor<float, 4>, xt::pytensor<float, 3>, xt::pytensor<uint8_t, 1>>, \
+        py::arg("modules").noconvert(), py::arg("assembled").noconvert(), py::arg("lut").noconvert());
 }

--- a/src/extra_foam/include/f_imageproc.hpp
+++ b/src/extra_foam/include/f_imageproc.hpp
@@ -11,6 +11,8 @@
 #define EXTRA_FOAM_IMAGE_PROC_H
 
 #include <cmath>
+#include <thread>
+#include <cstring>
 #include <type_traits>
 
 #include "xtensor/xview.hpp"
@@ -18,6 +20,8 @@
 #include "xtensor/xindex_view.hpp"
 
 #if defined(FOAM_USE_TBB)
+#include "tbb/task_arena.h"
+#include "tbb/partitioner.h"
 #include "tbb/parallel_for.h"
 #include "tbb/blocked_range2d.h"
 #endif
@@ -925,6 +929,367 @@ inline void binPhotons(const E& data, size_t adu_count, E& out)
     });
   }
 }
+
+  template<typename A>
+      inline auto generateAssemblyLUT(size_t data_size, const A& assembled)
+  {
+      auto lut = xt::eval(xt::zeros<size_t>({data_size}));
+
+      for (size_t i = 0; i < assembled.size(); ++i) {
+          if (!std::isnan(assembled.flat(i))) {
+              lut(static_cast<size_t>(assembled.flat(i))) = i;
+          }
+      }
+
+      return lut;
+  }
+
+  template<typename A>
+      inline auto generateAssemblyLUT2(size_t data_size, const A& assembled)
+  {
+      auto lut = xt::eval(xt::zeros<uint8_t>({data_size * 3}));
+
+      for (uint32_t i = 0; i < assembled.size(); ++i) {
+          if (!std::isnan(assembled.flat(i))) {
+              size_t idx_start = static_cast<size_t>(assembled.flat(i)) * 3;
+
+              // Pack the first 24 bytes of the 32-bit int into the LUT
+              std::memcpy(&(lut(idx_start)), &i, 3);
+          }
+      }
+
+      return lut;
+  }
+
+  /**
+   * Attempt 1: Linear LUT the size of the total input size.
+   *
+   * Too slow, LUT takes precious space on the CPU cache.
+   */
+  template<typename M, typename A, typename L>
+      inline void assembleDetectorData(const M& modules, A& assembled, const L& lut, int j)
+  {
+      if (lut.size() != modules.size()) {
+          throw std::invalid_argument("LUT is not the same size as the module array");
+      } else if (!modules.is_contiguous() || !assembled.is_contiguous() || !lut.is_contiguous() ||
+                 modules.layout() == xt::layout_type::dynamic ||
+                 !(modules.layout() == assembled.layout() && assembled.layout() == lut.layout())) {
+          throw std::invalid_argument("Non-contiguous inputs");
+      }
+
+      auto modules_array = modules.data();
+      auto assembled_array = assembled.data();
+
+      tbb::task_arena arena{j};
+      arena.initialize();
+      arena.execute([&] {
+          tbb::parallel_for(tbb::blocked_range<size_t>(0, modules.size()),
+                            [&] (const tbb::blocked_range<size_t> &block) {
+                                for (size_t i = block.begin(); i != block.end(); ++i) {
+                                    assembled_array[lut(i)] = modules_array[i];
+                                }
+                            });
+      });
+  }
+
+  /**
+   * Attempt 2: Use tile corner coordinates from extra-geom.
+   *
+   * This is unparallelized, but offers better performance than the first
+   * attempt. Need to figure out in which order to copy the module data though,
+   * and that's complicated.
+   */
+  template<typename M, typename A, typename L>
+      inline void assembleDetectorData2(const M& modules, A& assembled,
+                                        const L& lut,
+                                        const L& lut_rows, const L& lut_cols,
+                                        size_t tile_rows, size_t tile_cols)
+  {
+      auto modules_buffer = modules.data();
+      auto assembled_buffer = assembled.data();
+
+      auto dest_strides = assembled.strides();
+      size_t row_len = assembled.shape()[2];
+      size_t tiles_per_module = lut_rows.shape()[1];
+      size_t tile_row_len = static_cast<size_t>(modules.shape()[2] / tiles_per_module);
+
+      auto kernel = [&] (size_t pulse, size_t module) {
+          for (size_t tile = 0; tile < tiles_per_module; ++tile) {
+              size_t start = pulse * dest_strides[0] + lut(module, tile);
+              for (size_t row = 0; row < tile_rows; ++row) {
+                  for (size_t col = 0; col < tile_cols; ++col) {
+                      assembled_buffer[start + row * row_len + col] = modules(pulse, module, row, (tile * tile_cols) + col);
+                  }
+              }
+          }
+      };
+
+      size_t n_pulses = modules.shape()[0];
+      size_t n_modules = modules.shape()[1];
+
+      for (size_t pulse = 0; pulse < n_pulses; ++pulse) {
+          for (size_t module = 0; module < n_modules; ++module) {
+              kernel(pulse, module);
+          }
+      }
+
+      // tbb::parallel_for(tbb::blocked_range2d<size_t>(0, n_pulses, 0, n_pulses),
+      //                   [&] (const tbb::blocked_range2d<size_t>& block) {
+      //                       for (size_t pulse = block.rows().begin(); pulse != block.rows().end(); ++pulse) {
+      //                           for (size_t module = block.cols().begin(); module != block.cols().end(); ++module) {
+      //                               kernel(pulse, module);
+      //                           }
+      //                       }
+      //                   });
+  }
+
+  /**
+   * Attempt 3: Copy data into a column-major layout array to take advantage of
+   * cache locality.
+   *
+   * Can't use a (pulses, y, x) shaped output array, because then the elements
+   * for each pixel in a pulse will not be contiguous. If we're doing it this
+   * way, then we'll need a list of n (x, y) arrays.
+   */
+  template<typename M, typename A, typename L>
+      inline void assembleDetectorData3(const M& src, A& dest,
+                                        const L& lut,
+                                        const L& lut_rows, const L& lut_cols,
+                                        size_t tile_rows, size_t tile_cols)
+  {
+      if (!dest.is_contiguous() || dest.layout() != xt::layout_type::column_major) {
+          throw std::invalid_argument("Destination array does not have column-major layout");
+      }
+
+      auto src_buffer = src.data();
+      auto dest_buffer = dest.data();
+
+      auto dest_strides = dest.strides();
+      size_t col_len = dest.shape()[1];
+      size_t tiles_per_module = lut_rows.shape()[1];
+
+      for (size_t i = 0; i < dest.size(); ++i) {
+          dest_buffer[i] = static_cast<float>(i);
+      }
+      return;
+
+      auto kernel = [&] (size_t pulse, size_t module) {
+          for (size_t tile = 0; tile < tiles_per_module; ++tile) {
+              size_t start = pulse * dest_strides[0] + lut(module, tile);
+
+              for (size_t col = 0; col < tile_cols; ++col) {
+                  for (size_t row = 0; row < tile_rows; ++row) {
+                      dest_buffer[start + col * col_len + row] = src(pulse, module, (tile * tile_cols) + col, row);
+                  }
+              }
+          }
+      };
+
+      size_t n_pulses = src.shape()[0];
+      size_t n_modules = src.shape()[1];
+      for (size_t pulse = 0; pulse < n_pulses; ++pulse) {
+          for (size_t module = 0; module < n_modules; ++module) {
+              kernel(pulse, module);
+          }
+      }
+  }
+
+  /**
+   * Attempt 4: Linear LUT for a single pulse, reused for each pulse.
+   *
+   * Very close (within ~5-7%) to matching the current implementations'
+   * performance. Limitation is the amount of space used in the cache by the
+   * LUT.
+   */
+  template<typename M, typename A, typename L>
+      inline void assembleDetectorData4(const M& modules, A& assembled, const L& lut, int j)
+  {
+      if (!modules.is_contiguous() || !assembled.is_contiguous() || !lut.is_contiguous() ||
+          modules.layout() == xt::layout_type::dynamic ||
+          !(modules.layout() == assembled.layout() && assembled.layout() == lut.layout())) {
+          throw std::invalid_argument("Non-contiguous inputs");
+      }
+
+      static tbb::affinity_partitioner ap{ };
+
+      auto modules_array = modules.data();
+      auto assembled_array = assembled.data();
+      auto lut_array = lut.data();
+
+      size_t src_pulse_stride = modules.strides()[0];
+      size_t dest_pulse_stride = assembled.strides()[0];
+
+      tbb::task_arena arena{j};
+      arena.initialize();
+      arena.execute([&] {
+          tbb::parallel_for(tbb::blocked_range<size_t>(0, modules.size()),
+                            [&] (const tbb::blocked_range<size_t> &block) {
+                                for (size_t i = block.begin(); i != block.end(); ++i) {
+                                    size_t pulse = i >> 20;
+                                    size_t src_offset = pulse << 20;
+                                    size_t dest_offset = dest_pulse_stride * pulse;
+                                    assembled_array[dest_offset + lut_array[i - src_offset]] = modules_array[i];
+                                }
+                            },
+                            ap);
+      });
+  }
+
+  /**
+   * Attempt 5: Linear LUT for a single pulse, but packed into 24-bit ints for
+   * minimal effect on the cache.
+   *
+   * Good performance, very close to that of the current assembler. Consistenly
+   * faster than attempt 4 by a couple percentage points, and more stable.
+   */
+  template<typename M, typename A, typename L>
+      void assembleDetectorData5(const M& modules, A& assembled, const L& lut, int j)
+  {
+      if (!modules.is_contiguous() || !assembled.is_contiguous() || !lut.is_contiguous() ||
+          modules.layout() == xt::layout_type::dynamic ||
+          !(modules.layout() == assembled.layout() && assembled.layout() == lut.layout())) {
+          throw std::invalid_argument("Non-contiguous inputs");
+      }
+
+      auto modules_array = modules.data();
+      auto assembled_array = assembled.data();
+      auto lut_array = lut.data();
+
+      size_t src_pulse_stride = modules.strides()[0];
+      size_t dest_pulse_stride = assembled.strides()[0];
+
+      tbb::task_arena arena{j};
+      arena.initialize();
+      arena.execute([&] {
+          tbb::parallel_for(tbb::blocked_range<size_t>(0, modules.size()),
+                            [&] (const tbb::blocked_range<size_t> &block) {
+                                for (size_t i = block.begin(); i != block.end(); ++i) {
+                                    size_t pulse = i >> 20;
+                                    size_t src_offset = pulse << 20;
+                                    size_t dest_offset = dest_pulse_stride * pulse;
+
+                                    // Unpack the LUT value
+                                    uint32_t lut_idx_start = (i - src_offset) * 3;
+                                    uint32_t lut_value = 0;
+                                    std::memcpy(&lut_value, &lut_array[lut_idx_start], 4);
+                                    lut_value &= 0x00ffffff;
+
+                                    // Copy data
+                                    assembled_array[dest_offset + lut_value] = modules_array[i];
+                                }
+                            });
+      });
+  }
+
+  /**
+   * Attempt 6: Same as attempt 5, but with slightly more advanced code to only
+   * compute the LUT index when necessary.
+   *
+   * This consistently (but barely) outperforms attempt 5 by a margin of a
+   * couple percent. The performance also seems a bit more stable compared
+   * to attempt 5.
+   */
+  template<typename M, typename A, typename L>
+      void assembleDetectorData6(const M& modules, A& assembled, const L& lut)
+  {
+      if (!modules.is_contiguous() || !assembled.is_contiguous() || !lut.is_contiguous() ||
+          modules.layout() == xt::layout_type::dynamic ||
+          !(modules.layout() == assembled.layout() && assembled.layout() == lut.layout())) {
+          throw std::invalid_argument("Non-contiguous inputs");
+      }
+
+      auto modules_array = modules.data();
+      auto assembled_array = assembled.data();
+      auto lut_array = lut.data();
+
+      size_t src_pulse_stride = modules.strides()[0];
+      size_t dest_pulse_stride = assembled.strides()[0];
+
+      // This is a helper function to calculate the right index within the LUT
+      // for the current pixel.
+      auto compute_lut_idx = [dest_pulse_stride] (const size_t& module_idx, size_t& src_offset,
+                                                  size_t& dest_offset, uint32_t& lut_idx) {
+          // This is a trick that takes advantage of the fact that the 1M
+          // detectors (AGIPD/LPD) have exactly 2^20 pixels. Since in memory the
+          // module data for each pulse is in order after each other, we can get
+          // the pulse number by dividing the current location in the 1D array
+          // by the number of pixels per pulse. And since this is a multiple of
+          // two we can cheat and do a bitshift instead, which is faster than
+          // division.
+          size_t pulse = module_idx >> 20;
+
+          // Multiply by the pulse data length to get the index in the source
+          // data of the beginning of the current pulse. Again, since the number
+          // of pixels in a pulse is a power of 2 we can bitshift.
+          src_offset = pulse << 20;
+
+          // In the destination, the offset to the beginning of the current
+          // pulse is just the stride length of a pulse multiplied by the pulse
+          // number. The stride length may not be a power of 2 so we can't
+          // bitshift here.
+          dest_offset = dest_pulse_stride * pulse;
+
+          // Finally, calculate the index in the LUT for the lookup value for
+          // the current pixel. This is the offset within the current pulse,
+          // multiplied by 3 (because the LUT values take up 3 bytes in the
+          // array).
+          lut_idx = (module_idx - src_offset) * 3;
+      };
+
+      // Using an affinity_partitioner significantly (~10-30%) improves
+      // performance on Maxwell for trains with less than ~150 pulses.
+      static tbb::affinity_partitioner ap{ };
+      // On Maxwell this gives the best performance, though on more 'consumer'
+      // machines performance slightly improves (~10%) with half this number.
+      tbb::task_arena arena{std::thread::hardware_concurrency()};
+      arena.initialize();
+      arena.execute([&] {
+          tbb::parallel_for(tbb::blocked_range<size_t>(0, modules.size()),
+                            [&] (const tbb::blocked_range<size_t> &block) {
+                                // Check if this block is within a single pulse
+                                size_t start = block.begin();
+                                size_t start_pulse = start >> 20;
+                                size_t end = block.end();
+                                size_t end_pulse = end >> 20;
+                                bool intra_pulse = start_pulse == end_pulse;
+
+                                size_t src_offset = 0;
+                                size_t dest_offset = 0;
+                                uint32_t lut_idx_start = 0;
+                                compute_lut_idx(start, src_offset, dest_offset, lut_idx_start);
+
+                                for (size_t i = block.begin(); i != block.end(); ++i) {
+                                    // Compute the right LUT index. If the block
+                                    // we're processing is within a pulse then
+                                    // we can just increment the LUT index.
+                                    if (intra_pulse) {
+                                        lut_idx_start += 3;
+                                    } else {
+                                        // Otherwise we do the full calculation
+                                        compute_lut_idx(i, src_offset, dest_offset, lut_idx_start);
+                                    }
+
+                                    // Unpack the LUT value. Each value is a
+                                    // 24-bit int so technically we only need to
+                                    // copy 3 bytes, but copying 4 bytes is
+                                    // about 5x faster because then the compiler
+                                    // can optimize it down to a single assembly
+                                    // instruction.
+                                    uint32_t lut_value = 0;
+                                    std::memcpy(&lut_value, &lut_array[lut_idx_start], 4);
+                                    // Now we've copied 4 bytes into this int,
+                                    // but we only want the first 3 so we mask
+                                    // the high bits. This gives us the final
+                                    // value.
+                                    lut_value &= 0x00ffffff;
+
+                                    // Copy the pixel into the right position
+                                    assembled_array[dest_offset + lut_value] = modules_array[i];
+                                }
+                            },
+                            ap);
+      });
+  }
 
 /**
  * Inplace apply moving average for an image


### PR DESCRIPTION
Recently I've been playing around with re-implementing the geometry assembler, and I think it's at the point where we can figure out whether to go with it or not. It's not a clear decision because the results are... mixed. This PR is not meant to be merged, it's just for discussion.

TL;DR:
- The existing implementation computes the location for each pixel based on the tile/module number. The new implementation instead uses a LUT to compute the location for each pixel.
- On Maxwell, the new implementation is on average ~3 - 5% slower. The performance heavily depends on the machine architecture so results may vary. I haven't yet tested it on the online cluster.
- The new implementation is way simpler, it's orders of magnitude fewer SLOC.

So this all started when I had an idea a while ago about using LUT's to assemble geometry, because from pulse to pulse you don't need to compute the output location for each pixel in the input, that only depends on the geometry so it can be computed just once and re-used. I went through about 6 iterations of this idea before finding one that I think works well enough to be considered, which is [`assembleDetectorData6()`](https://github.com/European-XFEL/EXtra-foam/blob/assembler_rewrite/src/extra_foam/include/f_imageproc.hpp#L1193). This is a micro-optimized version of [`assembleDetectorData5()`](https://github.com/European-XFEL/EXtra-foam/blob/assembler_rewrite/src/extra_foam/include/f_imageproc.hpp#L1146), which is close enough that I would suggest reading the code for `assembleDetectorData5()` to understand `assembleDetectorData6()`. In turn, `assembleDetectorData5()` is a slightly optimized version of [`assembleDetectorData4()`](https://github.com/European-XFEL/EXtra-foam/blob/assembler_rewrite/src/extra_foam/include/f_imageproc.hpp#L1105). The other attempts I think are not worth considering because they're either broken or too slow.

Here's an overview of how it works:
1. A LUT is generated with [`generateAssemblyLUT2()`](https://github.com/European-XFEL/EXtra-foam/blob/assembler_rewrite/src/extra_foam/include/f_imageproc.hpp#L948) (this requires a specific input array from `extra-geom` to compute the LUT data). Let's define the number of pixels in a pulse as _N_, then the LUT is a 1D byte array of size `N * 3`. Each 3 bytes in the array are the first 3 bytes of a 4-byte int, and the idea is that since we can comfortably represent all possible LUT values (i.e. positions in the flattened output array) in 2^24 bits, we can cut the size of LUT by 25% by using 24-bit ints. This is to reduce the impact of the LUT on the CPU caches, the larger the LUT is the less space for the input and output arrays, and thus the more cache misses and worse performance.
2. The LUT is passed to the assembler function. The function iterates in parallel over the flattened input array, calculates the right location in the output array with the LUT, and copies the pixels. Calculating the right index in the LUT is slightly complicated so I'd suggest looking at [this commented helper function](https://github.com/European-XFEL/EXtra-foam/blob/assembler_rewrite/src/extra_foam/include/f_imageproc.hpp#L1210). Unpacking the 24-bit int into a `uint32` is also slightly complicated so there's some comments about that [here](https://github.com/European-XFEL/EXtra-foam/blob/assembler_rewrite/src/extra_foam/include/f_imageproc.hpp#L1272).

Here are some graphs that I made from running this on Maxwell for pulse lengths from 1 - 800 pulses (the 'reference implementation' is the existing implementation):
![image](https://user-images.githubusercontent.com/5361518/137476112-62f7e3d4-d93a-4744-aa67-8bc5c7c3d812.png)

Interestingly, this outperforms the reference until ~150 pulses, after which it degrades. I would put this down to a quirk of the architecture of the machine rather than anything related to the algorithm because I did not see this while testing on my own machine. It would be interesting to see if this is the case on the online cluster nodes.

![image](https://user-images.githubusercontent.com/5361518/137476151-b50857ba-33af-4ed4-afbb-37c82edca836.png)

This shows that after the initial improvement up to ~150 pulses, performance degrades and then stabilizes at around ~97%-ish the performance of the existing implementation.

![image](https://user-images.githubusercontent.com/5361518/137476191-45a82a72-0506-4dd1-b5a8-d375ef1e57e2.png)

And in practice, this translates to a slowdown of about 2ms for 800 pulses. At 400 pulses it's around 1ms, so assuming a linear slowdown then I guess this would translate to 4ms at 1600 pulses (though at that point assembly itself would take ~160ms). It's interesting to me that the performance of `assembleDetectorData4()` is so jittery, perhaps it's more sensitive to other workloads on the machine.

General thoughts:
- I believe the reason this doesn't perform as well compared to the reference is because of the space in the cache the LUT is taking, this should be made as small as possible.
- Even so, the current implementation will not scale for hundreds/thousands of pulses (at 800 pulses we're already at 80ms) so we will eventually need a faster way to assemble geometry.
- Assembly is a glorified copy, and GPUs are great at copying :grin: There are I/O issues but by optimizing the memory layout in a GPU we might be able to get good speedups on a CPU (already looking into this). Having said that, I think that there will always be a place for a high-performance CPU-only implementation, if only to use for testing offline.
- It's not clear to me that we should proceed with this implementation. It is far simpler, but the existing implementation already works and it is consistently faster, even if only by a few percentage points.

Thoughts? (anyone other than the reviewers, feel free to comment too :) )