### PR TITLE
Add support for special suites supporting both EXtra-foam and Karabo

### DIFF
--- a/extra_foam/special_suite/cam_view_w.py
+++ b/extra_foam/special_suite/cam_view_w.py
@@ -22,7 +22,7 @@ from .cam_view_proc import (
     CamViewProcessor, _DEFAULT_N_BINS, _DEFAULT_BIN_RANGE
 )
 from .special_analysis_base import (
-    create_special, QThreadKbClient, _BaseAnalysisCtrlWidgetS,
+    create_special, ClientType, _BaseAnalysisCtrlWidgetS,
     _SpecialAnalysisBase
 )
 
@@ -115,13 +115,14 @@ class CameraViewRoiHist(HistMixin, PlotWidgetF):
             self.updateTitle(mean, median, std)
 
 
-@create_special(CamViewCtrlWidget, CamViewProcessor, QThreadKbClient)
+@create_special(CamViewCtrlWidget, CamViewProcessor)
 class CamViewWindow(_SpecialAnalysisBase):
     """Main GUI for camera view."""
 
     icon = "cam_view.png"
     _title = "Camera view"
     _long_title = "Camera view"
+    _client_support = ClientType.KARABO_BRIDGE
 
     def __init__(self, topic):
         super().__init__(topic)

--- a/extra_foam/special_suite/gotthard_pump_probe_w.py
+++ b/extra_foam/special_suite/gotthard_pump_probe_w.py
@@ -22,7 +22,7 @@ from extra_foam.gui.plot_widgets import ImageViewF, PlotWidgetF
 from .config import _MAX_N_GOTTHARD_PULSES, GOTTHARD_DEVICE
 from .gotthard_pump_probe_proc import GotthardPpProcessor
 from .special_analysis_base import (
-    create_special, QThreadKbClient, _BaseAnalysisCtrlWidgetS,
+    create_special, ClientType, _BaseAnalysisCtrlWidgetS,
     _SpecialAnalysisBase
 )
 
@@ -226,13 +226,14 @@ class GotthardPpImageView(ImageViewF):
         self.setImage(data['corrected'])
 
 
-@create_special(GotthardPpCtrlWidget, GotthardPpProcessor, QThreadKbClient)
+@create_special(GotthardPpCtrlWidget, GotthardPpProcessor)
 class GotthardPumpProbeWindow(_SpecialAnalysisBase):
     """Main GUI for Gotthard pump-probe analysis."""
 
     icon = "Gotthard_pump_probe.png"
     _title = "Gotthard (pump-probe)"
     _long_title = "Gotthard pump-probe analysis"
+    _client_support = ClientType.KARABO_BRIDGE
 
     def __init__(self, topic):
         super().__init__(topic, with_dark=False)

--- a/extra_foam/special_suite/gotthard_w.py
+++ b/extra_foam/special_suite/gotthard_w.py
@@ -29,7 +29,7 @@ from .gotthard_proc import (
     GotthardProcessor, _DEFAULT_BIN_RANGE, _DEFAULT_N_BINS
 )
 from .special_analysis_base import (
-    create_special, QThreadKbClient, _BaseAnalysisCtrlWidgetS,
+    create_special, ClientType, _BaseAnalysisCtrlWidgetS,
     _SpecialAnalysisBase
 )
 
@@ -216,13 +216,14 @@ class GotthardHist(HistMixin, PlotWidgetF):
             self.updateTitle(mean, median, std)
 
 
-@create_special(GotthardCtrlWidget, GotthardProcessor, QThreadKbClient)
+@create_special(GotthardCtrlWidget, GotthardProcessor)
 class GotthardWindow(_SpecialAnalysisBase):
     """Main GUI for Gotthard analysis."""
 
     icon = "Gotthard.png"
     _title = "Gotthard"
     _long_title = "Gotthard analysis"
+    _client_support = ClientType.KARABO_BRIDGE
 
     def __init__(self, topic):
         super().__init__(topic)

--- a/extra_foam/special_suite/module_scan_w.py
+++ b/extra_foam/special_suite/module_scan_w.py
@@ -15,7 +15,7 @@ from PyQt5.QtWidgets import QGridLayout, QSplitter
 
 from .module_scan_proc import ModuleScanProcessor
 from .special_analysis_base import (
-    create_special, QThreadFoamClient, _BaseAnalysisCtrlWidgetS,
+    create_special, ClientType, _BaseAnalysisCtrlWidgetS,
     _SpecialAnalysisBase
 )
 from ..gui.plot_widgets import (
@@ -68,13 +68,14 @@ class ModuleScanRoiFomPlot(PlotWidgetF):
         self._mean.setData(data['mean'])
 
 
-@create_special(ModuleScanCtrlWidget, ModuleScanProcessor, QThreadFoamClient)
+@create_special(ModuleScanCtrlWidget, ModuleScanProcessor)
 class ModuleScanWindow(_SpecialAnalysisBase):
     """Main GUI for module scan."""
 
     icon = "module_scan.png"
     _title = "Module scan"
     _long_title = "Area detector module scan analysis"
+    _client_support = ClientType.EXTRA_FOAM
 
     def __init__(self, topic):
         super().__init__(topic, with_dark=False)

--- a/extra_foam/special_suite/multicam_view_w.py
+++ b/extra_foam/special_suite/multicam_view_w.py
@@ -16,7 +16,7 @@ from extra_foam.gui.plot_widgets import ImageViewF
 
 from .multicam_view_proc import MultiCamViewProcessor
 from .special_analysis_base import (
-    create_special, QThreadKbClient, _BaseAnalysisCtrlWidgetS,
+    create_special, ClientType, _BaseAnalysisCtrlWidgetS,
     _SpecialAnalysisBase
 )
 
@@ -83,13 +83,14 @@ class CameraView(ImageViewF):
         self.setTitle(data["channels"][self._index])
 
 
-@create_special(MultiCamViewCtrlWidget, MultiCamViewProcessor, QThreadKbClient)
+@create_special(MultiCamViewCtrlWidget, MultiCamViewProcessor)
 class MultiCamViewWindow(_SpecialAnalysisBase):
     """Main GUI for multi-camera view."""
 
     icon = "multi_cam_view.png"
     _title = "Multi-camera view"
     _long_title = "Multi-camera view"
+    _client_support = ClientType.KARABO_BRIDGE
 
     def __init__(self, topic):
         super().__init__(topic, with_dark=False)

--- a/extra_foam/special_suite/trxas_w.py
+++ b/extra_foam/special_suite/trxas_w.py
@@ -20,7 +20,7 @@ from extra_foam.gui.plot_widgets import (
 )
 
 from .special_analysis_base import (
-    create_special, QThreadFoamClient, _BaseAnalysisCtrlWidgetS,
+    create_special, ClientType, _BaseAnalysisCtrlWidgetS,
     _SpecialAnalysisBase
 )
 from .trxas_proc import (
@@ -205,13 +205,14 @@ class TrXasHeatmap(TimedImageViewF):
         self.setLabel('left', label)
 
 
-@create_special(TrXasCtrlWidget, TrXasProcessor, QThreadFoamClient)
+@create_special(TrXasCtrlWidget, TrXasProcessor)
 class TrXasWindow(_SpecialAnalysisBase):
     """Main GUI for tr-XAS analysis."""
 
     icon = "tr_xas.png"
     _title = "tr-XAS"
     _long_title = "Time-resolved X-ray Absorption Spectroscopy"
+    _client_support = ClientType.EXTRA_FOAM
 
     def __init__(self, topic):
         """Initialization."""

--- a/extra_foam/special_suite/vector_view.py
+++ b/extra_foam/special_suite/vector_view.py
@@ -18,7 +18,7 @@ from extra_foam.gui.plot_widgets import PlotWidgetF, TimedPlotWidgetF
 from extra_foam.pipeline.exceptions import ProcessingError
 
 from .special_analysis_base import (
-    create_special, profiler, QThreadFoamClient, QThreadWorker,
+    create_special, profiler, ClientType, QThreadWorker,
     _BaseAnalysisCtrlWidgetS, _SpecialAnalysisBase
 )
 
@@ -222,13 +222,14 @@ class VectorCorrelationPlot(TimedPlotWidgetF):
             self._plot.setData(vec1, vec2)
 
 
-@create_special(VectorViewCtrlWidget, VectorViewProcessor, QThreadFoamClient)
+@create_special(VectorViewCtrlWidget, VectorViewProcessor)
 class VectorViewWindow(_SpecialAnalysisBase):
     """Main GUI for vector view."""
 
     icon = "vector_view.png"
     _title = "Vector view"
     _long_title = "Vector view"
+    _client_support = ClientType.EXTRA_FOAM
 
     def __init__(self, topic):
         super().__init__(topic, with_dark=False, with_levels=False)

--- a/extra_foam/special_suite/xas_tim_w.py
+++ b/extra_foam/special_suite/xas_tim_w.py
@@ -28,7 +28,7 @@ from .xas_tim_proc import (
     _DEFAULT_N_BINS, _MAX_N_BINS,
 )
 from .special_analysis_base import (
-    create_special, QThreadKbClient, _BaseAnalysisCtrlWidgetS,
+    create_special, ClientType, _BaseAnalysisCtrlWidgetS,
     _SpecialAnalysisBase
 )
 
@@ -297,7 +297,7 @@ class XasTimXgmSpectrumPlot(TimedPlotWidgetF):
         self._count.setData(centers, counts)
 
 
-@create_special(XasTimCtrlWidget, XasTimProcessor, QThreadKbClient)
+@create_special(XasTimCtrlWidget, XasTimProcessor)
 class XasTimWindow(_SpecialAnalysisBase):
     """Main GUI for XAS-TIM analysis."""
 
@@ -305,6 +305,7 @@ class XasTimWindow(_SpecialAnalysisBase):
     _title = "XAS-TIM"
     _long_title = "X-ray Absorption Spectroscopy with transmission " \
                   "intensity monitor"
+    _client_support = ClientType.KARABO_BRIDGE
 
     def __init__(self, topic):
         super().__init__(topic, with_dark=False, with_levels=False)

--- a/extra_foam/special_suite/xas_tim_xmcd_w.py
+++ b/extra_foam/special_suite/xas_tim_xmcd_w.py
@@ -18,7 +18,7 @@ from extra_foam.gui.plot_widgets import TimedPlotWidgetF
 from extra_foam.gui.misc_widgets import FColor
 
 from .special_analysis_base import (
-    create_special, QThreadKbClient, _SpecialAnalysisBase
+    create_special, ClientType, _SpecialAnalysisBase
 )
 from .xas_tim_xmcd_proc import XasTimXmcdProcessor, _DEFAULT_CURRENT_THRESHOLD
 from .xas_tim_w import (
@@ -176,7 +176,7 @@ class XasTimXmcdSpectraPlot(TimedPlotWidgetF):
             self._displayed = index
 
 
-@create_special(XasTimXmcdCtrlWidget, XasTimXmcdProcessor, QThreadKbClient)
+@create_special(XasTimXmcdCtrlWidget, XasTimXmcdProcessor)
 class XasTimXmcdWindow(_SpecialAnalysisBase):
     """Main GUI for XAS-TIM-XMCD analysis."""
 
@@ -184,6 +184,7 @@ class XasTimXmcdWindow(_SpecialAnalysisBase):
     _title = "XAS-TIM-XMCD"
     _long_title = "X-ray Absorption Spectroscopy with transmission " \
                   "intensity monitor for X-ray Magnetic Circular Dichroism"
+    _client_support = ClientType.KARABO_BRIDGE
 
     def __init__(self, topic):
         super().__init__(topic, with_dark=False, with_levels=False)

--- a/extra_foam/special_suite/xes_timing_w.py
+++ b/extra_foam/special_suite/xes_timing_w.py
@@ -20,7 +20,7 @@ from extra_foam.gui.plot_widgets import (
 
 from .xes_timing_proc import XesTimingProcessor
 from .special_analysis_base import (
-    create_special, QThreadKbClient, _BaseAnalysisCtrlWidgetS,
+    create_special, ClientType, _BaseAnalysisCtrlWidgetS,
     _SpecialAnalysisBase
 )
 
@@ -97,13 +97,14 @@ class XesTimingDelayScan(TimedPlotWidgetF):
         self._plot.setData(*self._data['delay_scan'])
 
 
-@create_special(XesTimingCtrlWidget, XesTimingProcessor, QThreadKbClient)
+@create_special(XesTimingCtrlWidget, XesTimingProcessor)
 class XesTimingWindow(_SpecialAnalysisBase):
     """Main GUI for XES timing."""
 
     icon = "xes_timing.png"
     _title = "XES timing"
     _long_title = "X-ray emission spectroscopy timing tool"
+    _client_support = ClientType.KARABO_BRIDGE
 
     def __init__(self, topic):
         super().__init__(topic)


### PR DESCRIPTION
Some special suites may want to support processing data from both EXtra-foam and
Karabo bridges, this is now possible by passing ClientType.BOTH to the
constructor of _SpecialAnalysisBase(). More generally, this replaces the
`client_klass` parameter of create_special() with an argument to the
_SpecialAnalysisBase() constructor.

If both client types are supported, then a combo box will be available for the
user to select the appropriate source.