### PR TITLE
Convert floats to ints for Python 3.10 compatibility

### DIFF
--- a/extra_foam/gui/pyqtgraph/Point.py
+++ b/extra_foam/gui/pyqtgraph/Point.py
@@ -158,4 +158,4 @@ class Point(QtCore.QPointF):
         return Point(self)
         
     def toQPoint(self):
-        return QtCore.QPoint(*self)
+        return QtCore.QPoint(int(self.x()), int(self.y()))

--- a/extra_foam/gui/pyqtgraph/SignalProxy.py
+++ b/extra_foam/gui/pyqtgraph/SignalProxy.py
@@ -60,7 +60,7 @@ class SignalProxy(QtCore.QObject):
                 leakTime = max(0, (lastFlush + (1.0 / self.rateLimit)) - now)
                 
             self.timer.stop()
-            self.timer.start((min(leakTime, self.delay)*1000)+1)
+            self.timer.start(int(min(leakTime, self.delay) * 1000) + 1)
             
         
     def flush(self):

--- a/extra_foam/gui/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/extra_foam/gui/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1260,7 +1260,7 @@ class ViewBox(GraphicsWidget):
             mask[1-axis] = 0.0
 
         ## Scale or translate based on mouse button
-        if ev.button() & (QtCore.Qt.LeftButton | QtCore.Qt.MidButton):
+        if ev.button() in [QtCore.Qt.LeftButton, QtCore.Qt.MidButton]:
             if self.state['mouseMode'] == ViewBox.RectMode:
                 if ev.isFinish():  ## This is the final move in the drag; change the view scale now
                     #print "finish"

--- a/extra_foam/gui/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
+++ b/extra_foam/gui/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
@@ -119,7 +119,7 @@ class ViewBoxMenu(QtGui.QMenu):
             if state['autoRange'][i] is not False:
                 self.ctrl[i].autoRadio.setChecked(True)
                 if state['autoRange'][i] is not True:
-                    self.ctrl[i].autoPercentSpin.setValue(state['autoRange'][i]*100)
+                    self.ctrl[i].autoPercentSpin.setValue(int(state['autoRange'][i]) * 100)
             else:
                 self.ctrl[i].manualRadio.setChecked(True)
             self.ctrl[i].mouseCheck.setChecked(state['mouseEnabled'][i])

--- a/extra_foam/gui/pyqtgraph/widgets/GraphicsView.py
+++ b/extra_foam/gui/pyqtgraph/widgets/GraphicsView.py
@@ -356,7 +356,7 @@ class GraphicsView(QtGui.QGraphicsView):
     def mouseMoveEvent(self, ev):
         if self.lastMousePos is None:
             self.lastMousePos = Point(ev.pos())
-        delta = Point(ev.pos() - QtCore.QPoint(*self.lastMousePos))
+        delta = Point(ev.pos() - self.lastMousePos.toQPoint())
         self.lastMousePos = Point(ev.pos())
 
         QtGui.QGraphicsView.mouseMoveEvent(self, ev)


### PR DESCRIPTION
Python 3.10 included this change: https://bugs.python.org/issue37999. Turns out
that extra-foam's copy of pyqtgraph relies on this in some places, which results
in `TypeError`'s when running it with Python 3.10. These are just the places in
the code that I could find with manual/unit tests, it's possible that there are
more. The plan is to replace the internal copy with upstream though, so I don't
think it's worth doing anything more rigorous.

Note: maybe we should pin the Python version?