### PR TITLE
Configure LD_LIBRARY_PATH during installation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,8 +25,17 @@ Install **EXtra-foam**
     # you want to install into an existing environment, use `conda env update` instead.
     $ conda env create -f environment.yml
 
-    # Install
     $ conda activate extra_foam
+    # We need to set this variable so that the libraries from the conda
+    # environment are loaded first, in particular libstdc++. If the system
+    # libstdc++ is loaded first and it's too old for the version extra-foam was
+    # compiled against, then we might get nasty loader errors.
+    $ conda env config vars set LD_LIBRARY_PATH=${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}
+    # Re-activate the environment so the new variables take effect
+    $ conda deactivate
+    $ conda activate extra_foam
+
+    # Install extra-foam
     $ export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
     $ pip install .
 


### PR DESCRIPTION
Found an issue where the main extra-foam would start just fine, but the special
suites would fail with an error about `libstdc++`:
```
ImportError: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /home/james/git/EXtra-foam/extra_foam/algorithms/imageproc.cpython-310-x86_64-linux-gnu.so)
```

After much debugging, I found that this could be fixed by importing something
from `extra_foam.algorithms` _before_ anything from PyQt5 in
`extra_foam/special_suite/__init__.py`. A likely explanation is here:
https://stackoverflow.com/questions/59366730/changing-order-of-imports-results-in-error-in-python

TL;DR: if there are multiple shared objects in the search path with the same
name (i.e. `libstdc++.so.6`) then the first one loaded is the one that's used. So
if PyQt5, being a wrapper around a C++ library that's linked against `libstdc++`,
is loaded first, it's `libstdc++` is the one that'll be used for the
process. Swapping the order of the imports works because the `rpath` of
extra-foam's C++ libraries include the path to the `lib/` folder of the conda
environment, so conda's `libstdc++` will be loaded first even though that path is
not actually in the search path. By chance, extra-foam's C++ libraries are
loaded before PyQt5 in the main extra-foam, so that's why this issue didn't pop
up there (but I checked, adding an import to something from PyQt5 in
`extra_foam/services.py` does cause the error).

Possible fixes:
1. Statically link all the libraries. This time `libstdc++` was the
   problem, but in theory it could be any library.
2. Add the conda environments `lib/` directory to `LD_LIBRARY_PATH`.

I decided to go with the second fix because it's the simplest.