### PR TITLE
Gracefully handle 0s when plotting in log scale

### DIFF
--- a/extra_foam/gui/plot_widgets/tests/test_plot_items.py
+++ b/extra_foam/gui/plot_widgets/tests/test_plot_items.py
@@ -92,15 +92,16 @@ class TestPlotItems:
             item.setData(np.arange(2).astype(dtype), np.arange(3).astype(dtype))
 
         # test log mode
+        plot_bottom_right = np.log10(float(x[-1]))
         self._widget._plot_area._onLogXChanged(True)
         if dtype == float:
             _display()
-        assert item.boundingRect() == QRectF(0, 0, 1.0, 13.5)
+        assert item.boundingRect() == QRectF(0, 0, plot_bottom_right, 13.5)
         self._widget._plot_area._onLogYChanged(True)
         if dtype == float:
             _display()
         assert item.boundingRect().topLeft() == QPointF(0, 0)
-        assert item.boundingRect().bottomRight().x() == 1.0
+        assert item.boundingRect().bottomRight().x() == plot_bottom_right
         assert 1.2 > item.boundingRect().bottomRight().y() > 1.1
 
         # clear data

--- a/extra_foam/gui/pyqtgraph/graphicsItems/GraphicsObject.py
+++ b/extra_foam/gui/pyqtgraph/graphicsItems/GraphicsObject.py
@@ -129,7 +129,7 @@ class PlotItem(GraphicsObject):
         """Convert array result to logarithmic scale."""
         ret = np.nan_to_num(arr)
         ret[ret < 0] = 0
-        return np.log10(ret + 1)
+        return np.log10(ret, where=(ret > 0))
 
     def name(self):
         """An identity of the PlotItem.


### PR DESCRIPTION
Previously the behaviour was to add 1 before taking the log to avoid 0s causing
inf's in the output, but in some cases with very small values that gives wildly
incorrect results. Now we explicitly only take the log of non-zero values.

Before:
![image](https://user-images.githubusercontent.com/5361518/180026875-1eb14194-af1a-489a-b1a0-068fee40299e.png)

After:
![image](https://user-images.githubusercontent.com/5361518/180027051-fd434bf8-e30b-418b-831f-c8d3a4c8a9bc.png)
